### PR TITLE
docs(py_client): added usage of py_client to urbandict

### DIFF
--- a/urbandict-search/README.md
+++ b/urbandict-search/README.md
@@ -253,6 +253,8 @@ def read_data(fn, max_sample_size=10000):
 
 ### Query
 
+#### Via interactive input
+
 ```bash
 python app.py -t query
 ```
@@ -301,6 +303,16 @@ def print_topk(resp, word):
             print('{:>2d}:({:f}):{}'.format(
                 idx, score, kk.match_doc.raw_bytes.decode()))       
 ```
+
+#### Via jina python client
+
+As part of this tutorial, we also want to show, how you can query a running jina flow via the jina `py_client`. You can also run in a second console:
+
+```bash
+python http_query.py "luxury cars"
+```
+
+Beware, that the input and output processing are identical to searching on the flow locally. This guarantees a seemless switch from testing a flow towards using it in production.
 
 ## Dive into the Pods
 If you want to know more about Pods, keep reading. As shown above, we defined the Pods by giving the YAML files. Now let's move on to see what is exactly written in these magic YAML files.

--- a/urbandict-search/flow-query.yml
+++ b/urbandict-search/flow-query.yml
@@ -1,6 +1,7 @@
 !Flow
 with:
   read_only: true
+  port_grpc: 56798
 pods:
   splittor:
     yaml_path: yaml/craft-split.yml

--- a/urbandict-search/http_query.py
+++ b/urbandict-search/http_query.py
@@ -1,0 +1,36 @@
+import click
+
+from jina.clients import py_client
+
+
+def read_query_data(text):
+    yield "{}".format(text).encode("utf8")
+
+
+def print_topk(resp, word):
+    for d in resp.search.docs:
+        print(f"Ta-Dah🔮, here are what we found for: {word}")
+        for idx, kk in enumerate(d.topk_results):
+            score = kk.score.value
+            if score <= 0.0:
+                continue
+            print(
+                "{:>2d}:({:f}):{}".format(idx, score, kk.match_doc.raw_bytes.decode())
+            )
+
+
+@click.command()
+@click.argument("text")
+@click.option("--host", default="localhost")
+@click.option("--top_k", "-k", default=5)
+def main(text, host, top_k):
+    py_client(host=host, port_grpc=56798).dry_run()
+    ppr = lambda x: print_topk(x, text)
+
+    py_client(host=host, port_grpc=56798, top_k=top_k).search(
+        input_fn=read_query_data(text), output_fn=ppr
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This illustrates, that using the jina `py_client` is seamless and works identical to querying a local flow directly.

I append it to an existing example, since it is a bit to small of a learning to create a new tutorial. Fixing the port in the querying flow happens in order to not get confused by the random port selection of jina.

This should solve [358](https://github.com/jina-ai/jina/issues/358)