### PR TITLE
fix: fix the broken flows when gateway pods are shared

### DIFF
--- a/news-search/flow-index.yml
+++ b/news-search/flow-index.yml
@@ -1,12 +1,16 @@
 !Flow
 pods:
+  dispatcher:
+    yaml_path: _forward
+    replicas: 2
+
   doc_indexer:
     yaml_path: pods/doc_indexer/doc_indexer.yml
     replicas: 2
 
   extractor:
     yaml_path: pods/extractor/extractor.yml
-    needs: gateway
+    needs: dispatcher
     replicas: 2
 
   encoder:

--- a/southpark-search/flow-index.yml
+++ b/southpark-search/flow-index.yml
@@ -1,5 +1,9 @@
 !Flow
 pods:
+  dispatcher:
+    yaml_path: _forward
+    replicas: $REPLICAS
+    read_only: true
   splittor:
     yaml_path: yaml/craft-split.yml
     replicas: $REPLICAS
@@ -15,7 +19,7 @@ pods:
     separated_workspace: true
   doc_indexer:
     yaml_path: yaml/index-doc.yml
-    needs: gateway
+    needs: dispatcher
   join_all:
     yaml_path: _merge
     needs: [doc_indexer, chunk_indexer]

--- a/urbandict-search/flow-index.yml
+++ b/urbandict-search/flow-index.yml
@@ -1,5 +1,9 @@
 !Flow
 pods:
+  dispatcher:
+    yaml_path: _forward
+    replicas: $REPLICAS
+    read_only: True
   splittor:
     yaml_path: yaml/craft-split.yml
     replicas: $REPLICAS
@@ -15,7 +19,7 @@ pods:
     separated_workspace: true
   doc_indexer:
     yaml_path: yaml/index-doc.yml
-    needs: gateway
+    needs: dispatcher
   join_all:
     yaml_path: _merge
     needs: [doc_indexer, chunk_indexer]

--- a/webqa-search/flow-index.yml
+++ b/webqa-search/flow-index.yml
@@ -1,11 +1,15 @@
 !Flow
 pods:
+  dispatcher:
+    yaml_path: _forward
+    read_only: True
+
   doc_indexer:
     yaml_path: pods/doc_indexer/doc_indexer.yml
 
   extractor:
     yaml_path: pods/extractor/extractor.yml
-    needs: gateway
+    needs: dispatcher
     read_only: True
 
   encoder:


### PR DESCRIPTION
resolves #49 

fix the misusage of the `gateway` Pod. Under the hood, the `gateway` Pod uses `CONNECT` to get connected with the other Pods while the normal Pods use `BIND`. The `CONNECT` is not stable when more than one Pods get connected to the same one. Especially, when the two pathways diverge from the `gateway` and later merged at the `join`, this leads to troubles. When one message is lost in one pathway, the whole Flow would get stuck.