### PR TITLE
feat(examples): add crafter as compound executor

### DIFF
--- a/face-db-search/yaml/craft-load.yml
+++ b/face-db-search/yaml/craft-load.yml
@@ -1,18 +1,25 @@
-!ImageReader
-with:
-  channel_axis: $COLOR_CHANNEL_AXIS
+!CompoundExecutor
+components:
+  - !ImageReader
+    with:
+      channel_axis: $COLOR_CHANNEL_AXIS
+    metas:
+      name: reader
+  - !MySegmenter
+    metas:
+      name: segmenter
+metas:
+  py_modules: customized_executors.py
+  name: crafter
 requests:
   on:
-    IndexRequest:
+    [IndexRequest, SearchRequest]:
+      - !DocCraftDriver
+        with:
+          executor: reader
       - !SegmentDriver
         with:
-          method: craft
           save_buffer: True
-    SearchRequest:
-      - !URI2Buffer {}
-      - !SegmentDriver
-        with:
-          method: craft
-          save_buffer: True
+          executor: segmenter
     ControlRequest:
       - !ControlReqDriver {}

--- a/face-db-search/yaml/customized_executors.py
+++ b/face-db-search/yaml/customized_executors.py
@@ -4,7 +4,13 @@ __license__ = "Apache-2.0"
 
 import numpy as np
 from jina.executors.crafters.image import ImageChunkCrafter
+from jina.executors.crafters import BaseSegmenter
 from PIL import ImageOps
+
+
+class MySegmenter(BaseSegmenter):
+    def craft(self, blob, *args, **kwargs):
+        return [dict(blob=blob)]
 
 
 class ImageFlipper(ImageChunkCrafter):

--- a/face-db-search/yaml/index-doc.yml
+++ b/face-db-search/yaml/index-doc.yml
@@ -4,3 +4,19 @@ with:
 metas:
   name: docIndexer
   workspace: $TMP_WORKSPACE
+requests:
+  on:
+    SearchRequest:
+      - !DocKVSearchDriver
+        with:
+          method: query
+
+    IndexRequest:
+      - !DocPruneDriver
+        with:
+          pruned: ['chunks']
+      - !KVIndexDriver
+        with:
+          level: doc
+          method: add
+

--- a/flower-search/app.py
+++ b/flower-search/app.py
@@ -7,7 +7,8 @@ import os
 import string
 import random
 import sys
-
+import io
+from PIL import Image
 from jina.flow import Flow
 
 RANDOM_SEED = 14
@@ -60,7 +61,11 @@ def read_data(img_path, max_sample_size=-1):
         random.shuffle(fn_list)
         fn_list = fn_list[:max_sample_size]
     for fn in fn_list:
-        yield fn.encode('utf8')
+        image_buffer = io.BytesIO()
+        img = Image.open(fn)
+        img.save(image_buffer, format='PNG')
+        image_buffer.seek(0)
+        yield image_buffer.getvalue()
 
 
 def save_topk(resp, output_fn=None):

--- a/flower-search/yaml/craft-load.yml
+++ b/flower-search/yaml/craft-load.yml
@@ -1,10 +1,23 @@
-!ImageReader
-with:
-  channel_axis: $COLOR_CHANNEL_AXIS
+!CompoundExecutor
+components:
+  - !ImageReader
+    with:
+      channel_axis: $COLOR_CHANNEL_AXIS
+    metas:
+      name: reader
+  - !MySegmenter
+    metas:
+      name: segmenter
+metas:
+  py_modules: customized_executors.py
+  name: crafter
 requests:
   on:
-    [SearchRequest, IndexRequest, TrainRequest]:
+    [IndexRequest, SearchRequest, TrainRequest]:
+      - !DocCraftDriver
+        with:
+          executor: reader
       - !SegmentDriver
         with:
-          method: craft
           save_buffer: True
+          executor: segmenter

--- a/flower-search/yaml/customized_executors.py
+++ b/flower-search/yaml/customized_executors.py
@@ -4,7 +4,13 @@ __license__ = "Apache-2.0"
 
 import numpy as np
 from jina.executors.crafters.image import ImageChunkCrafter
+from jina.executors.crafters import BaseSegmenter
 from PIL import ImageOps
+
+
+class MySegmenter(BaseSegmenter):
+    def craft(self, blob, *args, **kwargs):
+        return [dict(blob=blob)]
 
 
 class ImageFlipper(ImageChunkCrafter):

--- a/flower-search/yaml/index-doc.yml
+++ b/flower-search/yaml/index-doc.yml
@@ -15,6 +15,7 @@ requests:
       - !DocPruneDriver
         with:
           pruned: ['chunks']
-      - !DocKVIndexDriver
+      - !KVIndexDriver
         with:
+          level: doc
           method: add


### PR DESCRIPTION
PR implementing proposal from #620. Linked PR in jina core: https://github.com/jina-ai/jina/pull/627

**Changes introduced**
- ImageReader should work together with a Segmenter inside a CompoundExecutor
- Correct DocDriver level
- Fix flower search app.py to send image buffer and not the uri in the buffer
