### PR TITLE
fix(flower): fix problems

### DIFF
--- a/flower-search/app.py
+++ b/flower-search/app.py
@@ -35,7 +35,7 @@ def main(task, num_docs):
     if task == 'index':
         f = Flow().load_config('flow-index.yml')
         with f:
-            f.index_files(f'{data_path}/*.jpg', size=num_docs, read_mode='rb')
+            f.index_files(f'{data_path}/*.jpg', size=num_docs, read_mode='rb', batch_size=2)
     elif task == 'query':
         f = Flow().load_config('flow-query.yml')
         f.use_rest_gateway()

--- a/flower-search/yaml/craft-load.yml
+++ b/flower-search/yaml/craft-load.yml
@@ -1,14 +1,9 @@
-!CompoundExecutor
-components:
-  - !ImageReader
-    with:
-      channel_axis: $COLOR_CHANNEL_AXIS
-      from_bytes: true
-    metas:
-      name: reader
+!ImageReader
+with:
+  channel_axis: $COLOR_CHANNEL_AXIS
+  from_bytes: true
 metas:
-  py_modules: customized_executors.py
-  name: crafter
+  name: reader
 requests:
   on:
     IndexRequest:


### PR DESCRIPTION
Running flower example shows an error:
jina.excepts.UnattachedDriver: <jina.drivers.craft.DocCraftDriver object at 0x7f53ad9df2b0>,
probably because the !CompoundExecutor only has one component.

This PR fixed it accordingly and add batch_size.
