### PR TITLE
fix(examples): adapt to new changes in proto

### DIFF
--- a/face-db-search/flow-query.yml
+++ b/face-db-search/flow-query.yml
@@ -26,7 +26,7 @@ pods:
     separated_workspace: true
     polling: all
     replicas: $SHARDS
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
   ranker:
     yaml_path: MinRanker
   doc_indexer:

--- a/face-db-search/yaml/craft-flip.yml
+++ b/face-db-search/yaml/craft-flip.yml
@@ -6,6 +6,6 @@ with:
 requests:
   on:
     [SearchRequest, IndexRequest]:
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/face-db-search/yaml/craft-normalize.yml
+++ b/face-db-search/yaml/craft-normalize.yml
@@ -7,6 +7,6 @@ with:
 requests:
   on:
     [SearchRequest, IndexRequest, TrainRequest]:
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/face-db-search/yaml/index-chunk.yml
+++ b/face-db-search/yaml/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:

--- a/face-db-search/yaml/index-doc.yml
+++ b/face-db-search/yaml/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:

--- a/faiss-search/app.py
+++ b/faiss-search/app.py
@@ -1,8 +1,6 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Generator, Any
-
 import click
 import os
 import string
@@ -37,19 +35,24 @@ def save_topk(resp, output_file, top_k):
             result = []
             fw.write('-' * 20)
             fw.write('\n')
-            fw.write('query id {}: \n {}'.format(query_id, np.frombuffer(d.blob.buffer, d.blob.dtype)))
+            fw.write('query id {}'.format(query_id))
             fw.write('\n')
             fw.write('matched vectors' + "*" * 10)
             fw.write('\n')
-            for idx, kk in enumerate(d.topk_results):
-                result.append(kk.match_doc.doc_id)
-                score = kk.score.value
+            print(d.matches)
+            for idx, match in enumerate(d.matches):
+                print(match)
+                print(dir(match))
+                # document id is 1-indexed because 0 is reserved for root doc.
+                id = match.match.id - 1
+                result.append(id)
+                score = match.score.value
                 if score < 0.0:
                     continue
-                m_fn = np.frombuffer(kk.match_doc.blob.buffer, kk.match_doc.blob.dtype)
+                m_fn = np.frombuffer(match.match.blob.buffer, match.match.blob.dtype)
                 fw.write('\n')
                 fw.write('Idx: {:>2d}:(DocId {}, Ranking score: {:f}): \n{}'.
-                         format(idx, kk.match_doc.doc_id, score, m_fn))
+                         format(idx, id, score, m_fn))
                 fw.write('\n')
             fw.write('\n')
             results.append(result)

--- a/faiss-search/flow-index.yml
+++ b/faiss-search/flow-index.yml
@@ -2,9 +2,6 @@
 metas:
   prefetch: 10
 pods:
-  crafter:
-    yaml_path: yaml/craft.yml
-    replicas: $REPLICAS
   encoder:
     yaml_path: yaml/encode.yml
     replicas: $REPLICAS
@@ -15,8 +12,8 @@ pods:
     yaml_path: yaml/index-chunk.yml
     volumes: './workspace'
   doc_indexer:
-    yaml_path: yaml/doc.yml
-    needs: crafter
+    yaml_path: yaml/index-doc.yml
+    needs: gateway
   join_all:
     yaml_path: _merge
     needs: [doc_indexer, faiss_indexer]

--- a/faiss-search/flow-query.yml
+++ b/faiss-search/flow-query.yml
@@ -2,9 +2,6 @@
 with:
   read_only: true
 pods:
-  crafter:
-    yaml_path: yaml/craft.yml
-    replicas: $REPLICAS
   encoder:
     yaml_path: yaml/encode.yml
     replicas: $REPLICAS

--- a/faiss-search/yaml/craft.yml
+++ b/faiss-search/yaml/craft.yml
@@ -1,5 +1,0 @@
-!BaseExecutor
-requests:
-  on:
-    [IndexRequest, SearchRequest]:
-      - !UnarySegmentDriver {}

--- a/faiss-search/yaml/index-chunk.yml
+++ b/faiss-search/yaml/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       workspace: './workspace'
       name: wrapidx
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/faiss-search/yaml/index-doc.yml
+++ b/faiss-search/yaml/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:

--- a/faiss-search/yaml/query-chunk.yml
+++ b/faiss-search/yaml/query-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !FaissIndexer
     with:
@@ -11,7 +11,7 @@ components:
           name: wrapidx
         with:
           index_filename: 'faiss_index.tgz'
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/flower-search/flow-query.yml
+++ b/flower-search/flow-query.yml
@@ -21,7 +21,7 @@ pods:
     yaml_path: yaml/index-chunk.yml
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
   ranker:
     yaml_path: MinRanker
   doc_indexer:

--- a/flower-search/yaml/craft-flip.yml
+++ b/flower-search/yaml/craft-flip.yml
@@ -6,6 +6,6 @@ with:
 requests:
   on:
     [SearchRequest, IndexRequest]:
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/flower-search/yaml/craft-load.yml
+++ b/flower-search/yaml/craft-load.yml
@@ -7,15 +7,13 @@ metas:
 requests:
   on:
     IndexRequest:
-      - !DocCraftDriver
+      - !CraftDriver
         with:
           executor: reader
-      - !UnarySegmentDriver {}
     SearchRequest:
       - !URI2Buffer {}
-      - !DocCraftDriver
+      - !CraftDriver
         with:
           executor: reader
-      - !UnarySegmentDriver {}
     ControRequest:
       - !ControlReqDriver {}

--- a/flower-search/yaml/index-chunk.yml
+++ b/flower-search/yaml/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -7,7 +7,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/flower-search/yaml/index-doc.yml
+++ b/flower-search/yaml/index-doc.yml
@@ -17,10 +17,9 @@ requests:
       - !MIMEDriver
         with:
           target: mime_type
-      - !PruneDriver
+      - !ExcludeQL
         with:
-          level: doc
-          pruned:
+          fields:
             - chunks
             - buffer
       - !KVIndexDriver

--- a/multilingual-search/flow-query.yml
+++ b/multilingual-search/flow-query.yml
@@ -16,7 +16,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
   ranker:
     yaml_path: MinRanker
   doc_indexer:

--- a/multires-lyrics-search/flows/query.yml
+++ b/multires-lyrics-search/flows/query.yml
@@ -16,7 +16,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
     timeout_ready: -1 # larger timeout as in query time will read all the data
   ranker:
     yaml_path: BiMatchRanker

--- a/multires-lyrics-search/pods/chunk-query.yml
+++ b/multires-lyrics-search/pods/chunk-query.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !AnnoyIndexer
     with:
@@ -9,7 +9,7 @@ components:
         metas:
           name: vecidx  # a customized name
           workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/multires-lyrics-search/pods/chunk.yml
+++ b/multires-lyrics-search/pods/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/multires-lyrics-search/pods/doc.yml
+++ b/multires-lyrics-search/pods/doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:

--- a/pokedex-with-bit/flow-query.yml
+++ b/pokedex-with-bit/flow-query.yml
@@ -17,7 +17,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
   ranker:
     yaml_path: BiMatchRanker

--- a/pokedex-with-bit/pods/chunk.yml
+++ b/pokedex-with-bit/pods/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/pokedex-with-bit/pods/craft.yml
+++ b/pokedex-with-bit/pods/craft.yml
@@ -20,7 +20,7 @@ requests:
       - !SegmentDriver
         with:
           executor: img_read
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           executor: img_norm
     SearchRequest:
@@ -28,7 +28,7 @@ requests:
       - !SegmentDriver
         with:
           executor: img_read
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           executor: img_norm
     ControlRequest:

--- a/southpark-search/flow-query.yml
+++ b/southpark-search/flow-query.yml
@@ -17,7 +17,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
   ranker:
     yaml_path: MinRanker
   doc_indexer:

--- a/southpark-search/pods/extract.yml
+++ b/southpark-search/pods/extract.yml
@@ -6,6 +6,6 @@ metas:
 requests:
   on:
     [SearchRequest, IndexRequest]:
-      - !DocCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/southpark-search/pods/index-chunk.yml
+++ b/southpark-search/pods/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -7,7 +7,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/southpark-search/pods/index-doc.yml
+++ b/southpark-search/pods/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:

--- a/southpark-search/pods/text_loader.py
+++ b/southpark-search/pods/text_loader.py
@@ -3,10 +3,10 @@ __license__ = "Apache-2.0"
 
 from typing import Dict
 
-from jina.executors.crafters import BaseDocCrafter
+from jina.executors.crafters import BaseCrafter
 
 
-class TextExtractor(BaseDocCrafter):
+class TextExtractor(BaseCrafter):
     def craft(self, text: str, *args, **kwargs) -> Dict:
         *_, s = text.split('[SEP]')
         return dict(weight=1., text=s, meta_info=text.encode('utf8'))

--- a/tumblr-gif-search/craft/craft.yml
+++ b/tumblr-gif-search/craft/craft.yml
@@ -10,16 +10,18 @@ requests:
       - !SegmentDriver
         with:
           executor: gif2chunk_preprocessor
-      - !DocPruneDriver
+      - !ExcludeQL
         with:
-          pruned: buffer  # we will never use buffer in the remaining pipeline
+          fields:
+            - buffer  # we will never use buffer in the remaining pipeline
     SearchRequest:
       - !URI2Buffer {}
       - !SegmentDriver
         with:
           executor: gif2chunk_preprocessor
-      - !DocPruneDriver
+      - !ExcludeQL
         with:
-          pruned: buffer  # we will never use buffer in the remaining pipeline
+          fields:
+            - buffer  # we will never use buffer in the remaining pipeline
     ControlRequest:
       - !ControlReqDriver {}

--- a/tumblr-gif-search/flow-query.yml
+++ b/tumblr-gif-search/flow-query.yml
@@ -15,7 +15,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
   ranker:
     yaml_path: BiMatchRanker

--- a/tumblr-gif-search/index/chunk.yml
+++ b/tumblr-gif-search/index/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/urbandict-search/flow-query.yml
+++ b/urbandict-search/flow-query.yml
@@ -17,7 +17,7 @@ pods:
     replicas: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    reducing_yaml_path: _merge_all
   ranker:
     yaml_path: MinRanker
   doc_indexer:

--- a/urbandict-search/yaml/index-chunk.yml
+++ b/urbandict-search/yaml/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -7,7 +7,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/urbandict-search/yaml/index-doc.yml
+++ b/urbandict-search/yaml/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:


### PR DESCRIPTION
Tries to advance some work and make it easier and faster for https://github.com/jina-ai/jina/pull/652 to be adopted in the examples.

I haven't been able to test many search queries because of some port_expose problem. Quite likely app.py should be adapted since when printing top_k results, the way we access protobuf data is not valid anymore.