### PR TITLE
Migrate face db search example to Jina 0.4.1

### DIFF
--- a/face-db-search/Encoder/Dockerfile
+++ b/face-db-search/Encoder/Dockerfile
@@ -10,4 +10,4 @@ RUN python -c "from facenet_pytorch import InceptionResnetV1; model = InceptionR
 
 COPY . /
 
-ENTRYPOINT ["jina", "pod", "--yaml-path", "encode.yml"]
+ENTRYPOINT ["jina", "pod", "--uses", "encode.yml"]

--- a/face-db-search/app.py
+++ b/face-db-search/app.py
@@ -12,12 +12,12 @@ image_src = '/tmp/jina/celeb/lfw/**/*.jpg'
 
 
 def config():
-    replicas = 2 if sys.argv[1] == 'index' else 1
+    parallel = 2 if sys.argv[1] == 'index' else 1
     shards = 8
 
     os.environ['TMP_WORKSPACE'] = '/tmp/jina/workspace'
     os.environ['COLOR_CHANNEL_AXIS'] = str(0)
-    os.environ['REPLICAS'] = str(replicas)
+    os.environ['PARALLEL'] = str(parallel)
     os.environ['SHARDS'] = str(shards)
     os.environ['WORKDIR'] = '/tmp/jina/workspace'
     os.makedirs(os.environ['WORKDIR'], exist_ok=True)

--- a/face-db-search/flow-index.yml
+++ b/face-db-search/flow-index.yml
@@ -3,30 +3,30 @@ metas:
   prefetch: 10
 pods:
   loader:
-    yaml_path: yaml/craft-load.yml
-    replicas: $REPLICAS
+    uses: yaml/craft-load.yml
+    parallel: $PARALLEL
     read_only: true
   flipper:
-    yaml_path: yaml/craft-flip.yml
-    replicas: $REPLICAS
+    uses: yaml/craft-flip.yml
+    parallel: $PARALLEL
     read_only: true
   normalizer:
-    yaml_path: yaml/craft-normalize.yml
-    replicas: $REPLICAS
+    uses: yaml/craft-normalize.yml
+    parallel: $PARALLEL
     read_only: true
   encoder:
-    image: jinaai/hub.executors.encoders.image.facenet
-    replicas: $REPLICAS
+    uses: jinaai/hub.executors.encoders.image.facenet
+    parallel: $PARALLEL
     timeout_ready: 600000
     read_only: true
   chunk_indexer:
-    yaml_path: yaml/index-chunk.yml
-    replicas: $SHARDS
+    uses: yaml/index-chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_indexer:
-    yaml_path: yaml/index-doc.yml
+    uses: yaml/index-doc.yml
     needs: loader
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_indexer, chunk_indexer]
     read_only: true

--- a/face-db-search/flow-query.yml
+++ b/face-db-search/flow-query.yml
@@ -5,29 +5,29 @@ with:
   port_expose: $JINA_PORT
 pods:
   loader:
-    yaml_path: yaml/craft-load.yml
+    uses: yaml/craft-load.yml
     read_only: true
-    replicas: $REPLICAS
+    parallel: $PARALLEL
   flipper:
-    yaml_path: yaml/craft-flip.yml
-    replicas: $REPLICAS
+    uses: yaml/craft-flip.yml
+    parallel: $PARALLEL
     read_only: true
   normalizer:
-    yaml_path: yaml/craft-normalize.yml
+    uses: yaml/craft-normalize.yml
     read_only: true
-    replicas: $REPLICAS
+    parallel: $PARALLEL
   encoder:
-    image: jinaai/hub.executors.encoders.image.facenet
+    uses: jinaai/hub.executors.encoders.image.facenet
     timeout_ready: 600000
-    replicas: $REPLICAS
+    parallel: $PARALLEL
     read_only: true
   chunk_indexer:
-    yaml_path: yaml/index-chunk.yml
+    uses: yaml/index-chunk.yml
     separated_workspace: true
     polling: all
-    replicas: $SHARDS
-    reducing_yaml_path: _merge_topk_chunks
+    shards: $SHARDS
+    uses_reducing: _merge_all
   ranker:
-    yaml_path: MinRanker
+    uses: MinRanker
   doc_indexer:
-    yaml_path: yaml/index-doc.yml
+    uses: yaml/index-doc.yml

--- a/face-db-search/make_html.py
+++ b/face-db-search/make_html.py
@@ -2,18 +2,17 @@ __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import os
-import webbrowser
 import io
+import webbrowser
 from PIL import Image
 from jina.flow import Flow
 from pkg_resources import resource_filename
-import numpy as np
 
 image_src = '/tmp/jina/celeb/lfw/**/*.jpg'
-replicas = 1
+parallel = 1
 shards = 8
 
-os.environ['REPLICAS'] = str(replicas)
+os.environ['PARALLEL'] = str(parallel)
 os.environ['SHARDS'] = str(shards)
 os.environ['TMP_WORKSPACE'] = '/tmp/jina/workspace'
 os.environ['TMP_RESULTS'] = '/tmp/jina/workspace/results'
@@ -31,9 +30,9 @@ def print_result(resp):
     for d in resp.search.docs:
         vi = d.uri
         result_html.append(f'<tr><td><img src="{vi}"/></td><td>')
-        for kk in d.topk_results:
-            im = Image.open(io.BytesIO(kk.match_doc.meta_info))
-            fname="{}.jpg".format(kk.match_doc.doc_id)
+        for match in d.matches:
+            im = Image.open(io.BytesIO(match.meta_info))
+            fname="{}.jpg".format(match.id)
             fname = os.path.join(os.environ['TMP_RESULTS'], fname)
             im.save(fname)
             result_html.append(f'<img src="{fname}" />')

--- a/face-db-search/yaml/craft-flip.yml
+++ b/face-db-search/yaml/craft-flip.yml
@@ -6,6 +6,6 @@ with:
 requests:
   on:
     [SearchRequest, IndexRequest]:
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/face-db-search/yaml/craft-load.yml
+++ b/face-db-search/yaml/craft-load.yml
@@ -4,15 +4,13 @@ with:
 requests:
   on:
     IndexRequest:
-      - !SegmentDriver
+      - !CraftDriver
         with:
           method: craft
-          save_buffer: True
     SearchRequest:
       - !URI2Buffer {}
-      - !SegmentDriver
+      - !CraftDriver
         with:
           method: craft
-          save_buffer: True
     ControlRequest:
       - !ControlReqDriver {}

--- a/face-db-search/yaml/craft-normalize.yml
+++ b/face-db-search/yaml/craft-normalize.yml
@@ -7,6 +7,6 @@ with:
 requests:
   on:
     [SearchRequest, IndexRequest, TrainRequest]:
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           method: craft

--- a/face-db-search/yaml/customized_executors.py
+++ b/face-db-search/yaml/customized_executors.py
@@ -8,8 +8,8 @@ from PIL import ImageOps
 
 
 class ImageFlipper(ImageChunkCrafter):
-    def craft(self, blob, doc_id, *args, **kwargs):
+    def craft(self, blob, *args, **kwargs):
         raw_img = self.load_image(blob)
         _img = ImageOps.mirror(raw_img)
         img = self.restore_channel_axis(np.asarray(_img))
-        return [{'doc_id': doc_id, 'blob': img.astype('float32')}, ]
+        return {'offset': 0, 'blob': img.astype('float32')}

--- a/face-db-search/yaml/index-chunk.yml
+++ b/face-db-search/yaml/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -7,7 +7,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE
-  - !BasePbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/face-db-search/yaml/index-doc.yml
+++ b/face-db-search/yaml/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:


### PR DESCRIPTION
This PR was aligned with issue #116 , migrate face db search example for Jina 0.4.1 release, includes:

1. Code migration based on [migration guide](https://github.com/jina-ai/jina/issues/702).
2. Minor refactoring to replace `SegmentDriver` with `CraftDriver` in `yaml/craft_load`, to make the example work.
3. Some minor changes on Readme.

Apart from this, while debugging `make_html.py`, `match.meta_info` gives me an empty buffer, might need to update `jina`. Please see attached image blow.

![image](https://user-images.githubusercontent.com/9794489/88714809-9870af80-d11d-11ea-9888-15f3e3d7c7d2.png)

@JoanFM Spent a lot of time helping me walking through this process, special thanks to him!