### PR TITLE
Migrate x-as-service example to Jina 0.4.1

### DIFF
--- a/pokedex-with-bit/README.md
+++ b/pokedex-with-bit/README.md
@@ -106,22 +106,22 @@ with:
   logserver: true
 pods:
   crafter:
-    yaml_path: pods/craft.yml
+    uses: pods/craft.yml
     read_only: true
   encoder:
-    yaml_path: pods/encode.yml
-    replicas: $REPLICAS
+    uses: pods/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 600000
     read_only: true
   chunk_idx:
-    yaml_path: pods/chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_idx:
-    yaml_path: pods/doc.yml
+    uses: pods/doc.yml
     needs: crafter
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_idx, chunk_idx]
 ```
 

--- a/pokedex-with-bit/app.py
+++ b/pokedex-with-bit/app.py
@@ -11,10 +11,10 @@ image_src = 'data/**/*.png'
 
 
 def config():
-    replicas = 2 if sys.argv[1] == 'index' else 1
+    parallel = 2 if sys.argv[1] == 'index' else 1
     shards = 8
 
-    os.environ['REPLICAS'] = str(replicas)
+    os.environ['PARALLEL'] = str(parallel)
     os.environ['SHARDS'] = str(shards)
     os.environ['WORKDIR'] = './workspace'
     os.makedirs(os.environ['WORKDIR'], exist_ok=True)

--- a/pokedex-with-bit/flow-index.yml
+++ b/pokedex-with-bit/flow-index.yml
@@ -3,21 +3,20 @@ with:
   logserver: true
 pods:
   crafter:
-    yaml_path: pods/craft.yml
+    uses: pods/craft.yml
     read_only: true
   encoder:
-    yaml_path: pods/encode.yml
-#    yaml_path: pods/encode-baseline.yml
-    replicas: $REPLICAS
+    uses: pods/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 600000
     read_only: true
   chunk_idx:
-    yaml_path: pods/chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_idx:
-    yaml_path: pods/doc.yml
+    uses: pods/doc.yml
     needs: gateway
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_idx, chunk_idx]

--- a/pokedex-with-bit/flow-query.yml
+++ b/pokedex-with-bit/flow-query.yml
@@ -5,21 +5,20 @@ with:
   port_expose: $JINA_PORT
 pods:
   chunk_seg:
-    yaml_path: pods/craft.yml
-    replicas: $REPLICAS
+    uses: pods/craft.yml
+    parallel: $PARALLEL
   tf_encode:
-    yaml_path: pods/encode.yml
-#    yaml_path: pods/encode-baseline.yml
-    replicas: $REPLICAS
+    uses: pods/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 600000
   chunk_idx:
-    yaml_path: pods/chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
   ranker:
-    yaml_path: BiMatchRanker
+    uses: BiMatchRanker
   doc_idx:
-    yaml_path: pods/doc.yml
+    uses: pods/doc.yml

--- a/pokedex-with-bit/make_html.py
+++ b/pokedex-with-bit/make_html.py
@@ -9,10 +9,10 @@ from pkg_resources import resource_filename
 
 # replace this to whatever dir has png, it doesn't care whether its is pokemon, as long as there is a PNG it's fine
 image_src = 'data/**/*.png'
-replicas = 1
+parallel = 1
 shards = 8
 
-os.environ['REPLICAS'] = str(replicas)
+os.environ['PARALLEL'] = str(parallel)
 os.environ['SHARDS'] = str(shards)
 os.environ['WORKDIR'] = './workspace'
 os.environ['JINA_PORT'] = os.environ.get('JINA_PORT', str(45678))
@@ -27,9 +27,9 @@ def print_result(resp):
     for d in resp.search.docs:
         vi = d.data_uri
         result_html.append(f'<tr><td><img src="{vi}"/></td><td>')
-        for kk in d.topk_results:
-            kmi = kk.match_doc.data_uri
-            result_html.append(f'<img src="{kmi}" style="opacity:{kk.score.value}"/>')
+        for match in d.matches:
+            uri = match.data_uri
+            result_html.append(f'<img src="{uri}" style="opacity:{match.score.value}"/>')
             # k['score']['explained'] = json.loads(kk.score.explained)
         result_html.append('</td></tr>\n')
 

--- a/pokedex-with-bit/pods/chunk.yml
+++ b/pokedex-with-bit/pods/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/pokedex-with-bit/pods/craft.yml
+++ b/pokedex-with-bit/pods/craft.yml
@@ -20,7 +20,7 @@ requests:
       - !SegmentDriver
         with:
           executor: img_read
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           executor: img_norm
     SearchRequest:
@@ -28,7 +28,7 @@ requests:
       - !SegmentDriver
         with:
           executor: img_read
-      - !ChunkCraftDriver
+      - !CraftDriver
         with:
           executor: img_norm
     ControlRequest:

--- a/x-as-service/README.md
+++ b/x-as-service/README.md
@@ -62,12 +62,12 @@ In a real-world application, you may want to use one of our [`BaseIndexer` class
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+          parallel=2, timeout_ready=20000))
 ```
 
-This creates a `Flow` with two `Pods`, corresponding to the first and second step described above. Here we start two `replicas`, so there will be two encoders running in parallel. `timeout_ready` is set to 20s (20000ms) as loading the pretrained model and starting pytorch take some time.
+This creates a `Flow` with two `Pods`, corresponding to the first and second step described above. Here we start two `parallel`, so there will be two encoders running in parallel. `timeout_ready` is set to 20s (20000ms) as loading the pretrained model and starting pytorch take some time.
 
 In the second step, we use [transformers](https://github.com/huggingface/transformers) for embedding computation. In the example above, we use a prebuilt image from [Jina Hub](https://github.com/jina-ai/jina-hub). If you do not want to use Docker or if you already have transformer and pytorch installed locally, you can simply do:
 
@@ -75,9 +75,9 @@ In the second step, we use [transformers](https://github.com/huggingface/transfo
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', yaml_path='enc.yml',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='enc.yml',
+          parallel=2, timeout_ready=20000))
 ```
 
 with `enc.yml` such as 
@@ -138,11 +138,11 @@ Then you can change the local flow to:
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
           host='192.168.1.100', # the ip/hostname of the remote GPU machine
           port_expose=34567,
-          replicas=2, timeout_ready=20000))
+          parallel=2, timeout_ready=20000))
 ```
 
 Done!

--- a/x-as-service/app.py
+++ b/x-as-service/app.py
@@ -22,9 +22,9 @@ def print_embed(req):
 
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+          parallel=2, timeout_ready=20000))
 
 with f:
     f.index(input_fn, batch_size=32, callback=print_embed)


### PR DESCRIPTION
This PR was aligned with issue #116  , migrate x-as-service example for Jina 0.4.1 release, includes:

1. Code migration based on migration guide.
2. Minor changes on Readme.