### PR TITLE
Migrate x-as-service to jina 0.4.1

### DIFF
--- a/x-as-service/README.md
+++ b/x-as-service/README.md
@@ -62,12 +62,12 @@ In a real-world application, you may want to use one of our [`BaseIndexer` class
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+          parallel=2, timeout_ready=20000))
 ```
 
-This creates a `Flow` with two `Pods`, corresponding to the first and second step described above. Here we start two `replicas`, so there will be two encoders running in parallel. `timeout_ready` is set to 20s (20000ms) as loading the pretrained model and starting pytorch take some time.
+This creates a `Flow` with two `Pods`, corresponding to the first and second step described above. Here we start two `parallel`, so there will be two encoders running in parallel. `timeout_ready` is set to 20s (20000ms) as loading the pretrained model and starting pytorch take some time.
 
 In the second step, we use [transformers](https://github.com/huggingface/transformers) for embedding computation. In the example above, we use a prebuilt image from [Jina Hub](https://github.com/jina-ai/jina-hub). If you do not want to use Docker or if you already have transformer and pytorch installed locally, you can simply do:
 
@@ -75,9 +75,9 @@ In the second step, we use [transformers](https://github.com/huggingface/transfo
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', yaml_path='enc.yml',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='enc.yml',
+          parallel=2, timeout_ready=20000))
 ```
 
 with `enc.yml` such as 
@@ -138,11 +138,11 @@ Then you can change the local flow to:
 from jina.flow import Flow
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
           host='192.168.1.100', # the ip/hostname of the remote GPU machine
           port_expose=34567,
-          replicas=2, timeout_ready=20000))
+          parallel=2, timeout_ready=20000))
 ```
 
 Done!

--- a/x-as-service/app.py
+++ b/x-as-service/app.py
@@ -22,9 +22,9 @@ def print_embed(req):
 
 
 f = (Flow(callback_on_body=True)
-     .add(name='spit', yaml_path='Sentencizer')
-     .add(name='encode', image='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
-          replicas=2, timeout_ready=20000))
+     .add(name='spit', uses='Sentencizer')
+     .add(name='encode', uses='jinaai/hub.executors.encoders.nlp.transformers-pytorch',
+          parallel=2, timeout_ready=20000))
 
 with f:
     f.index(input_fn, batch_size=32, callback=print_embed)


### PR DESCRIPTION
This PR was aligned with issue #116 , migrate x-as-service  example for Jina 0.4.1 release, includes:

1. Code migration based on migration guide.
2. Minor changes on Readme.

To run this example, you should build pytorch-transformer image locally using jina 0.4.1 with Dockerfile:

```docker
FROM pytorch/pytorch:1.4-cuda10.1-cudnn7-runtime

RUN pip install transformers --no-cache-dir --compile && \
    python -c "from transformers import *; x='bert-base-uncased'; BertModel.from_pretrained(x); BertTokenizer.from_pretrained(x)"

RUN pip install git+https://github.com/jina-ai/jina.git/@master

ENTRYPOINT ["jina", "pod", "--uses", "TransformerTorchEncoder"]
```

And command:

```python
docker build -f Dockerfile -t jinaai/hub.executors.encoders.nlp.transformers-pytorch .
```