### PR TITLE
fix(urbandict): add splitter

### DIFF
--- a/urbandict-search/app.py
+++ b/urbandict-search/app.py
@@ -27,8 +27,8 @@ def print_topk(resp, word):
             score = match.score.value
             if score <= 0.0:
                 continue
-            doc = match.chunks[0].text
-            word, word_def = doc.split('+-=', maxsplit=1)
+            word_def = match.chunks[0].text
+            word = match.meta_info.decode()
             print('> {:>2d}({:.2f}). {}: "{}"'.format(idx, score, word, word_def.strip()))
 
 

--- a/urbandict-search/flow-query.yml
+++ b/urbandict-search/flow-query.yml
@@ -3,8 +3,8 @@ with:
   read_only: true
   port_expose: 45678
 pods:
-  splittor:
-    uses: yaml/craft-split.yml
+  splitter:
+    uses: yaml/query-craft.yml
     parallel: $PARALLEL
     read_only: true
   encoder:

--- a/urbandict-search/yaml/craft-split.yml
+++ b/urbandict-search/yaml/craft-split.yml
@@ -1,5 +1,32 @@
-!Sentencizer
-with:
-  min_sent_len: 3
-  max_sent_len: 128
-  punct_chars: '.,;!?:'
+!CompoundExecutor
+components:
+  - !Splitter
+    metas:
+      name: splitter  # a customized name
+      workspace: $TMP_WORKSPACE
+      requests:
+        on:
+          [SearchRequest, IndexRequest]:
+            - !CraftDriver
+              with:
+                method: craft
+  - !Sentencizer
+    with:
+      min_sent_len: 3
+      max_sent_len: 128
+      punct_chars: '.,;!?:'
+    metas:
+      name: sentencizer  # a customized name
+name: crafter
+workspace: $TMP_WORKSPACE
+metas:
+  py_modules: splitter.py
+requests:
+  on:
+    [SearchRequest, IndexRequest]:
+      - !CraftDriver
+        with:
+          executor: splitter
+      - !SegmentDriver
+        with:
+          executor: sentencizer

--- a/urbandict-search/yaml/encode.yml
+++ b/urbandict-search/yaml/encode.yml
@@ -2,4 +2,4 @@
 with:
   pooling_strategy: cls
   model_name: distilbert-base-cased
-  max_length: 96
+  max_length: 10

--- a/urbandict-search/yaml/encode.yml
+++ b/urbandict-search/yaml/encode.yml
@@ -2,4 +2,5 @@
 with:
   pooling_strategy: cls
   model_name: distilbert-base-cased
-  max_length: 10
+  max_length: 96
+

--- a/urbandict-search/yaml/index-doc.yml
+++ b/urbandict-search/yaml/index-doc.yml
@@ -4,6 +4,3 @@ with:
 metas:
   name: docIndexer
   workspace: $TMP_WORKSPACE
-
-
-

--- a/urbandict-search/yaml/query-craft.yml
+++ b/urbandict-search/yaml/query-craft.yml
@@ -1,0 +1,5 @@
+!Sentencizer
+with:
+  min_sent_len: 3
+  max_sent_len: 128
+  punct_chars: '.,;!?:'

--- a/urbandict-search/yaml/splitter.py
+++ b/urbandict-search/yaml/splitter.py
@@ -1,0 +1,12 @@
+__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
+from typing import Dict
+
+from jina.executors.crafters import BaseCrafter
+
+
+class Splitter(BaseCrafter):
+    def craft(self, text: str, *args, **kwargs) -> Dict:
+        word, definitions = text.split('+-=')
+        return dict(text=definitions, meta_info=word.encode())


### PR DESCRIPTION
Hey @YueLiu-jina .

This is the idea I had, it is now broken due to a problem in `transformers` when dealing with different lengths of tokens.

The idea is that here we have the `word` and the set of `definitions`. The word does not have to be `encoded`, therefore I add a splitter before the `sentencizer` to extract the word and set it as `meta_info`, so that later we can say. The closest word to the `definition given` is the one extracted from the `doc.matches[idx].meta_info.decode()`.

Does this sound like a good idea @nan-wang?

If the aim of the example is to search for `words` given a `definition`, the word itself should not be encoded.

Now it works if the versions required by https://github.com/jina-ai/jina/issues/753 are used.

I understand the flow. We are using the closest definition which is the single definition present in the first chunk of a `match`.

But what I do not understand is why the `match.text` is empty. It it missing in the `DocIndexer`, or just not extracted? @nan-wang any light on this?

Anyway. Now the `example` works with this change.


