### PR TITLE
Migrate multilingual search to jina 0.4.1

### DIFF
--- a/multilingual-search/app.py
+++ b/multilingual-search/app.py
@@ -25,7 +25,7 @@ def get_random_ws(workspace_path, length=8):
 
 
 def configure_model(data_dir = '/tmp/jina/multilingual'):
-    os.environ['REPLICAS'] = str(2)
+    os.environ['PARALLEL'] = str(2)
     os.environ['SHARDS'] = str(2)
     os.environ['TMP_DATA_DIR'] = data_dir
     os.environ['PATH_TO_BPE_CODES'] = data_dir + '/93langs.fcodes'
@@ -35,15 +35,15 @@ def configure_model(data_dir = '/tmp/jina/multilingual'):
     
 
 def print_topk(resp, word):
-    for _doc in resp.search.docs:
+    for doc in resp.search.docs:
         print(f'\n\n\nHere are what we found for: {word}')
         # print(_doc.topk_results)
-        for idx, _match_doc in enumerate(_doc.topk_results):
-            score = _match_doc.score.value
+        for idx, match in enumerate(doc.matches):
+            score = match.score.value
             if score < 0.0:
                 continue
-            _text = _match_doc.match_doc.text
-            print('> {:>2d}({:.2f}). "{}"'.format(idx, score, _text.strip()))
+            text = match.text
+            print('> {:>2d}({:.2f}). "{}"'.format(idx, score, text.strip()))
 
 
 def read_query_data(text):

--- a/multilingual-search/flow-index.yml
+++ b/multilingual-search/flow-index.yml
@@ -1,22 +1,22 @@
 !Flow
 pods:
   crafter:
-    yaml_path: pods/crafter/craft.yml
-    replicas: $REPLICAS
+    uses: pods/crafter/craft.yml
+    parallel: $PARALLEL
     read_only: true
   encoder:
-    yaml_path: pods/encoder/encode.yml
-    replicas: $REPLICAS
+    uses: pods/encoder/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 1200000
     read_only: true
   chunk_indexer:
-    yaml_path: pods/chunk_indexer/index-chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk_indexer/index-chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_indexer:
-    yaml_path: pods/doc_indexer/index-doc.yml
+    uses: pods/doc_indexer/index-doc.yml
     needs: gateway
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_indexer, chunk_indexer]
     read_only: true

--- a/multilingual-search/flow-query.yml
+++ b/multilingual-search/flow-query.yml
@@ -3,21 +3,21 @@ with:
   read_only: true
 pods:
   crafter:
-    yaml_path: pods/crafter/craft.yml
-    replicas: $REPLICAS
+    uses: pods/crafter/craft.yml
+    parallel: $PARALLEL
     read_only: true
   encoder:
-    yaml_path: pods/encoder/encode.yml
-    replicas: $REPLICAS
+    uses: pods/encoder/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 1200000
     read_only: true
   chunk_indexer:
-    yaml_path: pods/chunk_indexer/index-chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk_indexer/index-chunk.yml
+    shards: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    uses_reducing: _merge_all
   ranker:
-    yaml_path: MinRanker
+    uses: MinRanker
   doc_indexer:
-    yaml_path: pods/doc_indexer/index-doc.yml
+    uses: pods/doc_indexer/index-doc.yml

--- a/multilingual-search/pods/chunk_indexer/index-chunk.yml
+++ b/multilingual-search/pods/chunk_indexer/index-chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -7,7 +7,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/multilingual-search/pods/doc_indexer/index-doc.yml
+++ b/multilingual-search/pods/doc_indexer/index-doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:


### PR DESCRIPTION
This PR was aligned with issue #116 , migrate multilingual search example for Jina 0.4.1 release, includes:

1. Code migration based on migration guide.

Need to be noted that this example do not have a readme file.