### PR TITLE
Migrate tumplr gif search to jina 0.4.1

### DIFF
--- a/multires-lyrics-search/app.py
+++ b/multires-lyrics-search/app.py
@@ -14,10 +14,10 @@ num_docs = os.environ.get('MAX_DOCS', 50000)
 
 
 def config():
-    replicas = 6 if sys.argv[1] == 'index' else 1
+    parallel = 6 if sys.argv[1] == 'index' else 1
     shards = 8
 
-    os.environ['REPLICAS'] = str(replicas)
+    os.environ['PARALLEL'] = str(parallel)
     os.environ['SHARDS'] = str(shards)
     os.environ['WORKDIR'] = './workspace'
     os.makedirs(os.environ['WORKDIR'], exist_ok=True)

--- a/multires-lyrics-search/flows/index.yml
+++ b/multires-lyrics-search/flows/index.yml
@@ -1,20 +1,20 @@
 !Flow
 pods:
   crafter:
-    yaml_path: pods/craft.yml
+    uses: pods/craft.yml
     read_only: true
   encoder:
-    yaml_path: pods/encode.yml
-    replicas: $REPLICAS
+    uses: pods/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 600000
     read_only: true
   chunk_idx:
-    yaml_path: pods/chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_idx:
-    yaml_path: pods/doc.yml
+    uses: pods/doc.yml
     needs: gateway
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_idx, chunk_idx]

--- a/multires-lyrics-search/flows/query.yml
+++ b/multires-lyrics-search/flows/query.yml
@@ -5,20 +5,20 @@ with:
   port_expose: $JINA_PORT
 pods:
   chunk_seg:
-    yaml_path: pods/craft.yml
-    replicas: $REPLICAS
+    uses: pods/craft.yml
+    parallel: $PARALLEL
   tf_encode:
-    yaml_path: pods/encode.yml
-    replicas: $REPLICAS
+    uses: pods/encode.yml
+    parallel: $PARALLEL
     timeout_ready: 600000
   chunk_idx:
-    yaml_path: pods/chunk.yml
-    replicas: $SHARDS
+    uses: pods/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    uses_reducing: _merge_all
     timeout_ready: -1 # larger timeout as in query time will read all the data
   ranker:
-    yaml_path: BiMatchRanker
+    uses: BiMatchRanker
   doc_idx:
-    yaml_path: pods/doc.yml
+    uses: pods/doc.yml

--- a/multires-lyrics-search/pods/chunk-query.yml
+++ b/multires-lyrics-search/pods/chunk-query.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !AnnoyIndexer
     with:
@@ -9,7 +9,7 @@ components:
         metas:
           name: vecidx  # a customized name
           workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/multires-lyrics-search/pods/chunk.yml
+++ b/multires-lyrics-search/pods/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:

--- a/multires-lyrics-search/pods/doc.yml
+++ b/multires-lyrics-search/pods/doc.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc.gzip
 metas:

--- a/tumblr-gif-search/app.py
+++ b/tumblr-gif-search/app.py
@@ -12,10 +12,10 @@ GIF_BLOB = '/Volumes/TOSHIBA-4T/dataset/thumblr-gif-data/*.gif'
 
 
 def config():
-    replicas = 2 if sys.argv[1] == 'index' else 1
+    parallel = 2 if sys.argv[1] == 'index' else 1
     shards = 8
 
-    os.environ['REPLICAS'] = str(replicas)
+    os.environ['PARALLEL'] = str(parallel)
     os.environ['SHARDS'] = str(shards)
     os.environ['WORKDIR'] = './workspace'
     os.makedirs(os.environ['WORKDIR'], exist_ok=True)

--- a/tumblr-gif-search/craft/craft.yml
+++ b/tumblr-gif-search/craft/craft.yml
@@ -10,16 +10,20 @@ requests:
       - !SegmentDriver
         with:
           executor: gif2chunk_preprocessor
-      - !DocPruneDriver
+      - !ExcludeQL
         with:
-          pruned: buffer  # we will never use buffer in the remaining pipeline
+          fields:
+            - buffer
+            - chunks
     SearchRequest:
       - !URI2Buffer {}
       - !SegmentDriver
         with:
           executor: gif2chunk_preprocessor
-      - !DocPruneDriver
+      - !ExcludeQL
         with:
-          pruned: buffer  # we will never use buffer in the remaining pipeline
+          fields:
+            - buffer
+            - chunks
     ControlRequest:
       - !ControlReqDriver {}

--- a/tumblr-gif-search/flow-index.yml
+++ b/tumblr-gif-search/flow-index.yml
@@ -3,22 +3,22 @@ with:
   logserver: true
 pods:
   chunk_seg:
-    yaml_path: craft/craft.yml
-    replicas: $REPLICAS
+    uses: craft/craft.yml
+    parallel: $PARALLEL
     read_only: true
   tf_encode:
-    yaml_path: encode/encode.yml
+    uses: encode/encode.yml
     needs: chunk_seg
-    replicas: $REPLICAS
+    parallel: $PARALLEL
     read_only: true
   chunk_idx:
-    yaml_path: index/chunk.yml
-    replicas: $SHARDS
+    uses: index/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
   doc_idx:
-    yaml_path: index/doc.yml
+    uses: index/doc.yml
     needs: gateway
   join_all:
-    yaml_path: _merge
+    uses: _merge
     needs: [doc_idx, chunk_idx]
     read_only: true

--- a/tumblr-gif-search/flow-query.yml
+++ b/tumblr-gif-search/flow-query.yml
@@ -5,19 +5,19 @@ with:
   rest_api: true
 pods:
   chunk_seg:
-    yaml_path: craft/craft.yml
-    replicas: $REPLICAS
+    uses: craft/craft.yml
+    parallel: $PARALLEL
   tf_encode:
-    yaml_path: encode/encode.yml
-    replicas: $REPLICAS
+    uses: encode/encode.yml
+    parallel: $PARALLEL
   chunk_idx:
-    yaml_path: index/chunk.yml
-    replicas: $SHARDS
+    uses: index/chunk.yml
+    shards: $SHARDS
     separated_workspace: true
     polling: all
-    reducing_yaml_path: _merge_topk_chunks
+    uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
   ranker:
-    yaml_path: BiMatchRanker
+    uses: BiMatchRanker
   doc_idx:
-    yaml_path: index/doc.yml
+    uses: index/doc.yml

--- a/tumblr-gif-search/index/chunk.yml
+++ b/tumblr-gif-search/index/chunk.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -6,7 +6,7 @@ components:
     metas:
       name: vecidx  # a customized name
       workspace: $WORKDIR
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk.gz
     metas:


### PR DESCRIPTION
This PR was aligned with issue #116 , migrate tumblr search example for Jina 0.4.1 release, includes:

1. Code migration based on migration guide.
2. Minor changes on Readme.

Note, the script `gif_download.py` might cause an exception while downloading gifs, something needs to be investigate further more later.