### PR TITLE
Migrate news search to 0.4.1

### DIFF
--- a/urbandict-search/yaml/query-craft.yml
+++ b/urbandict-search/yaml/query-craft.yml
@@ -1,0 +1,5 @@
+!Sentencizer
+with:
+  min_sent_len: 3
+  max_sent_len: 128
+  punct_chars: '.,;!?:'

--- a/urbandict-search/yaml/query-craft.yml
+++ b/urbandict-search/yaml/query-craft.yml
@@ -1,5 +1,0 @@
-!Sentencizer
-with:
-  min_sent_len: 3
-  max_sent_len: 128
-  punct_chars: '.,;!?:'

--- a/zh/news-search/app.py
+++ b/zh/news-search/app.py
@@ -15,9 +15,11 @@ os.environ['TMP_WORKSPACE'] = workspace_path
 def print_topk(resp):
     print(f'以下是相似的新闻内容:')
     for d in resp.search.docs:
-        for tk in d.topk_results:
-            item = json.loads(tk.match_doc.text)
-            print('👉%s.............' % item['content'][:50])
+        print(d)
+        # for match in d.matches:
+        #     item = match.text
+        #     print('item: ', item)
+        #     print('👉%s.............' % item['content'][:50])
 
 def read_query_data(item):
     yield '{}'.format(json.dumps(item, ensure_ascii=False))
@@ -26,12 +28,13 @@ def read_query_data(item):
 @click.command()
 @click.option('--task', '-t', default='query')
 @click.option('--top_k', '-k', default=5)
-def main(task, top_k):
+@click.option('--num_docs', '-n', default=100)
+def main(task, top_k, num_docs):
     if task == 'index':
         data_fn = os.path.join(workspace_path, "pre_news2016zh_valid.json")
         flow = Flow().load_config('flow-index.yml')
         with flow:
-            flow.index_lines(filepath=data_fn, size=100, batch_size=32)
+            flow.index_lines(filepath=data_fn, size=num_docs, batch_size=32)
 
     elif task == 'query':
         flow = Flow().load_config('flow-query.yml')

--- a/zh/news-search/flow-index.yml
+++ b/zh/news-search/flow-index.yml
@@ -8,10 +8,11 @@ pods:
 #    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
     uses: pods/encoder/encoder.yml
     timeout_ready: 6000000
+    parallel: 2
 
   chunk_indexer:
     uses: pods/chunk_indexer/chunk_indexer.yml
-#    shards: 2
+    shards: 2
 
   doc_indexer:
     uses: pods/doc_indexer/doc_indexer.yml

--- a/zh/news-search/flow-index.yml
+++ b/zh/news-search/flow-index.yml
@@ -1,24 +1,24 @@
 !Flow
 pods:
-  doc_indexer:
-    yaml_path: pods/doc_indexer/doc_indexer.yml
-    replicas: 2
 
   extractor:
-    yaml_path: pods/extractor/extractor.yml
+    uses: pods/extractor/extractor.yml
     needs: gateway
-    replicas: 2
+    parallel: 2
 
   encoder:
-    image: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
     timeout_ready: 6000000
-    replicas: 2
 
   chunk_indexer:
-    yaml_path: pods/chunk_indexer/chunk_indexer.yml
-    replicas: 2
+    uses: pods/chunk_indexer/chunk_indexer.yml
+    shards: 2
+
+  doc_indexer:
+    uses: pods/doc_indexer/doc_indexer.yml
+    needs: gateway
 
   join:
-    yaml_path: _merge
+    uses: _merge
     needs: [chunk_indexer, doc_indexer]
-    replicas: 2
+    read_only: True

--- a/zh/news-search/flow-index.yml
+++ b/zh/news-search/flow-index.yml
@@ -1,18 +1,17 @@
 !Flow
 pods:
-
   extractor:
     uses: pods/extractor/extractor.yml
-    needs: gateway
     parallel: 2
 
   encoder:
-    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+#    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+    uses: pods/encoder/encoder.yml
     timeout_ready: 6000000
 
   chunk_indexer:
     uses: pods/chunk_indexer/chunk_indexer.yml
-    shards: 2
+#    shards: 2
 
   doc_indexer:
     uses: pods/doc_indexer/doc_indexer.yml

--- a/zh/news-search/flow-query.yml
+++ b/zh/news-search/flow-query.yml
@@ -5,17 +5,17 @@ pods:
     parallel: 2
 
   encoder:
-    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+#    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+    uses: pods/encoder/encoder.yml
     timeout_ready: 6000000
 
   chunk_indexer:
     uses: pods/chunk_indexer/chunk_indexer.yml
     timeout_ready: 60000
-    shards: 2
+#    shards: 2
 
   ranker:
     uses: pods/ranker/ranker.yml
-    parallel: 2
 
   doc_indexer:
     uses: pods/doc_indexer/doc_indexer.yml

--- a/zh/news-search/flow-query.yml
+++ b/zh/news-search/flow-query.yml
@@ -8,11 +8,12 @@ pods:
 #    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
     uses: pods/encoder/encoder.yml
     timeout_ready: 6000000
+    parallel: 2
 
   chunk_indexer:
     uses: pods/chunk_indexer/chunk_indexer.yml
     timeout_ready: 60000
-#    shards: 2
+    shards: 2
 
   ranker:
     uses: pods/ranker/ranker.yml

--- a/zh/news-search/flow-query.yml
+++ b/zh/news-search/flow-query.yml
@@ -1,24 +1,21 @@
 !Flow
 pods:
   extractor:
-    yaml_path: pods/extractor/extractor.yml
-    replicas: 2
+    uses: pods/extractor/extractor.yml
+    parallel: 2
 
   encoder:
-    image: jinaai/hub.executors.encoders.nlp.transformers-hitscir
+    uses: jinaai/hub.executors.encoders.nlp.transformers-hitscir
     timeout_ready: 6000000
-    replicas: 2
 
   chunk_indexer:
-    yaml_path: pods/chunk_indexer/chunk_indexer.yml
+    uses: pods/chunk_indexer/chunk_indexer.yml
     timeout_ready: 60000
-    replicas: 2
+    shards: 2
 
   ranker:
-    yaml_path: pods/ranker/ranker.yml
-    replicas: 2
+    uses: pods/ranker/ranker.yml
+    parallel: 2
 
   doc_indexer:
-    yaml_path: pods/doc_indexer/doc_indexer.yml
-    timeout_ready: 60000
-    replicas: 2
+    uses: pods/doc_indexer/doc_indexer.yml

--- a/zh/news-search/pods/chunk_indexer/chunk_indexer.yml
+++ b/zh/news-search/pods/chunk_indexer/chunk_indexer.yml
@@ -1,4 +1,4 @@
-!ChunkIndexer
+!CompoundIndexer
 components:
   - !NumpyIndexer
     with:
@@ -8,7 +8,7 @@ components:
       name: vecidx_index
       workspace: $TMP_WORKSPACE
 
-  - !ChunkPbIndexer
+  - !BinaryPbIndexer
     with:
       index_filename: chunk_index.gzip
     metas:

--- a/zh/news-search/pods/doc_indexer/doc_indexer.yml
+++ b/zh/news-search/pods/doc_indexer/doc_indexer.yml
@@ -1,4 +1,4 @@
-!DocPbIndexer
+!BinaryPbIndexer
 with:
   index_filename: doc_index.gzip
 

--- a/zh/news-search/pods/encoder/encoder.yml
+++ b/zh/news-search/pods/encoder/encoder.yml
@@ -1,0 +1,10 @@
+!TransformerRobertaEncoder
+metas:
+  py_modules: transformer_roberta.py
+
+requests:
+  on:
+    [SearchRequest, IndexRequest]:
+      - !EncodeDriver
+        with:
+          method: encode

--- a/zh/news-search/pods/encoder/transformer_roberta.py
+++ b/zh/news-search/pods/encoder/transformer_roberta.py
@@ -1,0 +1,25 @@
+__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
+from jina.executors.encoders.nlp.transformer import TransformerTorchEncoder
+
+
+class TransformerRobertaEncoder(TransformerTorchEncoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # self.model_name = 'hfl/chinese-roberta-wwm-ext'
+        self.tmp_model_path = 'hfl/chinese-roberta-wwm-ext'
+        self.pooling_strategy = 'cls'
+        self.max_length = 32
+
+    def get_tokenizer(self):
+        from transformers import BertTokenizer
+        _tokenizer = BertTokenizer.from_pretrained(self.tmp_model_path)
+        _tokenizer.padding_side = 'right'
+        return _tokenizer
+
+    def get_model(self):
+        from transformers import BertModel
+        _model = BertModel.from_pretrained(self.tmp_model_path)
+        self.to_device(_model)
+        return _model

--- a/zh/news-search/pods/encoder/transformers-hitscir/Dockerfile
+++ b/zh/news-search/pods/encoder/transformers-hitscir/Dockerfile
@@ -1,0 +1,13 @@
+FROM pytorch/manylinux-cuda100:latest
+
+RUN pip3 install transformers --no-cache-dir --compile
+RUN python3 -c "from transformers import BertModel, BertTokenizer; x='hfl/chinese-roberta-wwm-ext'; BertModel.from_pretrained(x); BertTokenizer.from_pretrained(x)"
+
+RUN pip install jina==0.4.1
+
+ENV TMP_WORKSPACE /tmp/jina/news/
+ENV BATCH_SIZE 32
+
+ADD *.py *.yml ./
+
+ENTRYPOINT ["jina", "pod", "--uses", "roberta.yml"]

--- a/zh/news-search/pods/encoder/transformers-hitscir/README.md
+++ b/zh/news-search/pods/encoder/transformers-hitscir/README.md
@@ -1,0 +1,3 @@
+# HIT-SCIR Roberta base wwm ext model
+
+this is a roberta base wwm ext model made of hit-scir, It pre-downloaded the `hfl/chinese-roberta-wwm-ext` model in the image, so you don't need to download it again when using the image. 

--- a/zh/news-search/pods/encoder/transformers-hitscir/manifest.yml
+++ b/zh/news-search/pods/encoder/transformers-hitscir/manifest.yml
@@ -1,0 +1,9 @@
+name: HIT SCIR Roberta Base
+description: it's a roberta base wwm ext model made of hit-scir.
+author: Jina AI Dev-Team (dev-team@jina.ai)
+url: https://jina.ai
+documentation: https://github.com/jina-ai/jina-hub
+version: 0.0.0
+vendor: Jina AI Limited
+license: apache-2.0
+update: nightly

--- a/zh/news-search/pods/encoder/transformers-hitscir/roberta.yml
+++ b/zh/news-search/pods/encoder/transformers-hitscir/roberta.yml
@@ -1,0 +1,11 @@
+!TransformerRobertaEncoder
+metas:
+  on_gpu: true
+  batch_size: $BATCH_SIZE
+  workspace: $TMP_WORKSPACE
+  name: transformer_roberta_encoder
+  py_modules: transformer_roberta.py
+
+with:
+  max_length: 128
+  pooling_strategy: cls

--- a/zh/news-search/pods/encoder/transformers-hitscir/transformer_roberta.py
+++ b/zh/news-search/pods/encoder/transformers-hitscir/transformer_roberta.py
@@ -1,0 +1,19 @@
+from jina.executors.encoders.nlp.transformer import TransformerTorchEncoder
+
+
+class TransformerRobertaEncoder(TransformerTorchEncoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model_name = 'hfl/chinese-roberta-wwm-ext'
+
+    def get_tokenizer(self):
+        from transformers import BertTokenizer
+        _tokenizer = BertTokenizer.from_pretrained(self.tmp_model_path)
+        _tokenizer.padding_side = 'right'
+        return _tokenizer
+
+    def get_model(self):
+        from transformers import BertModel
+        _model = BertModel.from_pretrained(self.tmp_model_path)
+        self.to_device(_model)
+        return _model

--- a/zh/news-search/pods/extractor/extractor.py
+++ b/zh/news-search/pods/extractor/extractor.py
@@ -9,9 +9,9 @@ from jina.executors.crafters.nlp.split import Sentencizer
 
 
 class WeightSentencizer(Sentencizer):
-    def craft(self, text: str, id: int, *args, **kwargs) -> List[Dict]:
+    def craft(self, text: str, *args, **kwargs) -> List[Dict]:
         content = json.loads(text)['content']
-        results = super().craft(content, id)
+        results = super().craft(content)
         weights = np.linspace(1, 0.1, len(results))
         for result, weight in zip(results, weights):
             result['weight'] = weight

--- a/zh/news-search/pods/extractor/extractor.py
+++ b/zh/news-search/pods/extractor/extractor.py
@@ -9,9 +9,9 @@ from jina.executors.crafters.nlp.split import Sentencizer
 
 
 class WeightSentencizer(Sentencizer):
-    def craft(self, text: str, doc_id: int, *args, **kwargs) -> List[Dict]:
+    def craft(self, text: str, id: int, *args, **kwargs) -> List[Dict]:
         content = json.loads(text)['content']
-        results = super().craft(content, doc_id)
+        results = super().craft(content, id)
         weights = np.linspace(1, 0.1, len(results))
         for result, weight in zip(results, weights):
             result['weight'] = weight

--- a/zh/news-search/pods/ranker/ranker.yml
+++ b/zh/news-search/pods/ranker/ranker.yml
@@ -7,6 +7,7 @@ requests:
       - !Chunk2DocRankDriver
         with:
           method: score
-      - !DocPruneDriver
+      - !ExcludeReqQL
         with:
-          pruned: chunks
+          fields:
+            - request

--- a/zh/news-search/pods/ranker/ranker.yml
+++ b/zh/news-search/pods/ranker/ranker.yml
@@ -7,7 +7,8 @@ requests:
       - !Chunk2DocRankDriver
         with:
           method: score
-      - !ExcludeReqQL
+      - !ExcludeQL
         with:
           fields:
-            - request
+            - buffer
+            - chunks

--- a/zh/news-search/prepare_data.py
+++ b/zh/news-search/prepare_data.py
@@ -19,8 +19,6 @@ for file in fz.namelist():
         continue
     fz.extract(file, workspace)
 
-print(sys.argv)
-
 for filename in os.listdir(workspace):
     if not filename.endswith('.json') or filename.startswith('pre_'):
         continue

--- a/zh/news-search/prepare_data.py
+++ b/zh/news-search/prepare_data.py
@@ -4,6 +4,7 @@ __license__ = "Apache-2.0"
 import json
 import os
 import zipfile
+import sys
 
 root_path = '/tmp/jina/'
 demo_name = 'news'
@@ -16,12 +17,15 @@ if not os.path.exists(workspace):
 fz = zipfile.ZipFile(os.path.join('/tmp', 'new2016zh.zip'), 'r')
 
 for file in fz.namelist():
+    if sys.argv[1] == 'valid' and not file.endswith('valid.json'):
+        continue
     fz.extract(file, workspace)
 
 for filename in os.listdir(workspace):
-    if not filename.endswith('.json'):
+    if not filename.endswith('.json') or filename.startswith('pre_'):
         continue
-
+    if sys.argv[1] == 'valid' and (filename.startswith('pre_') or not filename.endswith('valid.json')):
+        continue
     items = []
     with open(os.path.join(workspace, filename), 'r', encoding='utf-8') as f:
         for line in f:

--- a/zh/news-search/prepare_data.py
+++ b/zh/news-search/prepare_data.py
@@ -9,22 +9,22 @@ import sys
 root_path = '/tmp/jina/'
 demo_name = 'news'
 workspace = os.path.join(root_path, demo_name)
-if not os.path.exists(root_path):
-    os.mkdir(root_path)
 if not os.path.exists(workspace):
     os.mkdir(workspace)
 
 fz = zipfile.ZipFile(os.path.join('/tmp', 'new2016zh.zip'), 'r')
 
 for file in fz.namelist():
-    if sys.argv[1] == 'valid' and not file.endswith('valid.json'):
+    if len(sys.argv)>1 and sys.argv[1] == 'valid' and not file.endswith('valid.json'):
         continue
     fz.extract(file, workspace)
+
+print(sys.argv)
 
 for filename in os.listdir(workspace):
     if not filename.endswith('.json') or filename.startswith('pre_'):
         continue
-    if sys.argv[1] == 'valid' and (filename.startswith('pre_') or not filename.endswith('valid.json')):
+    if len(sys.argv)>1 and sys.argv[1] == 'valid' and not filename.endswith('valid.json'):
         continue
     items = []
     with open(os.path.join(workspace, filename), 'r', encoding='utf-8') as f:

--- a/zh/news-search/prepare_data.py
+++ b/zh/news-search/prepare_data.py
@@ -10,7 +10,7 @@ root_path = '/tmp/jina/'
 demo_name = 'news'
 workspace = os.path.join(root_path, demo_name)
 if not os.path.exists(workspace):
-    os.mkdir(workspace)
+    os.makedirs(workspace)
 
 fz = zipfile.ZipFile(os.path.join('/tmp', 'new2016zh.zip'), 'r')
 


### PR DESCRIPTION
part of #116 

Since the dataset is so large, processing the whole dataset may take too long. So a `valid` mode is added. One can use it by `python prepare_data.py valid`

This PR is far from finish, I will continue work on this. This news search meets the same problem as urbandict, even worse.

1. In `resp.search.docs`, some matches looks like following ,which contains no search result.

```
matches {
  id: 37
  weight: 1.0
  length: 32
  mime_type: "text/plain"
  score {
    value: 6.565842151641846
    op_name: "NumpyIndexer"
    ref_id: 1
  }
}
```

2. Some other matches have other problem:
```
matches {
  id: 26
  chunks {
    id: 1901
    weight: 1.0
    length: 3
    mime_type: "text/plain"
    text: "(www."
    level_depth: 1
    parent_id: 26
    location: 0
    location: 10
    embedding {
    }
  }
  chunks {
    id: 1902
    weight: 0.550000011920929
    length: 3
    mime_type: "text/plain"
    text: "ahnews."
    level_depth: 1
    parent_id: 26
    location: 10
    location: 17
    offset: 1
    embedding {
    }
  }
  chunks {
    id: 1903
    weight: 0.10000000149011612
    length: 3
    mime_type: "text/plain"
    text: "org)1025"
    level_depth: 1
    parent_id: 26
    location: 17
    location: 110
    offset: 2
    embedding {
    }
  }
  weight: 1.0
  length: 32
  mime_type: "text/plain"
  score {
    value: 6.933157444000244
    op_name: "NumpyIndexer"
    ref_id: 1
  }
}
```
This is unbelievable, because the whole dataset is in Chinese, while the `chunks.text` contains only alphabets and numbers.

A full version  of `resp.search.docs` is here
[resp.search.docs.txt](https://github.com/jina-ai/examples/files/5034208/resp.search.docs.txt)
