### PR TITLE
fix(my-first-jina-app): correct git repo

### DIFF
--- a/my-first-jina-app/README.md
+++ b/my-first-jina-app/README.md
@@ -104,8 +104,8 @@ You should have also read the key concepts at the top of this page to get a good
 Let's get the basic files we need to get moving:
 
 ```
-git clone git@github.com:alexcg1/my-first-jina-app.git
-cd my-first-jina-app
+git clone https://github.com/jina-ai/examples.git
+cd examples/my-first-jina-app
 ```
 
 ### Cookiecutter


### PR DESCRIPTION
I'd left the old git repo in the README. I've corrected it to download the examples repo instead so user always has latest version of the tutorial and associated files

Fixes #170 

Note: After discussion with team, there's consensus to fix cookiecutter, therefore this example can be brought back from the dead. Hence me pushing the fix