### PR TITLE
fix: change metrix to metric

### DIFF
--- a/face-db-search/yaml/index-chunk.yml
+++ b/face-db-search/yaml/index-chunk.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE

--- a/flower-search/yaml/index-chunk.yml
+++ b/flower-search/yaml/index-chunk.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE

--- a/mnist-with-mindspore/pods/index.yml
+++ b/mnist-with-mindspore/pods/index.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE

--- a/southpark-search/README.md
+++ b/southpark-search/README.md
@@ -394,7 +394,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE

--- a/southpark-search/pods/index-chunk.yml
+++ b/southpark-search/pods/index-chunk.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vec.gz
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx  # a customized name
       workspace: $TMP_WORKSPACE

--- a/zh/news-search/pods/chunk_indexer/chunk_indexer.yml
+++ b/zh/news-search/pods/chunk_indexer/chunk_indexer.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vecidx_index.gzip
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx_index
       workspace: $TMP_WORKSPACE

--- a/zh/webqa-search/README.md
+++ b/zh/webqa-search/README.md
@@ -408,7 +408,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vecidx_index.gzip
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx_index
       workspace: $TMP_WORKSPACE

--- a/zh/webqa-search/pods/chunk_indexer/chunk_indexer.yml
+++ b/zh/webqa-search/pods/chunk_indexer/chunk_indexer.yml
@@ -3,7 +3,7 @@ components:
   - !NumpyIndexer
     with:
       index_filename: vecidx_index.gzip
-      metrix: cosine
+      metric: cosine
     metas:
       name: vecidx_index
       workspace: $TMP_WORKSPACE


### PR DESCRIPTION
- Changed `metrix` to `metric` in all relevant examples - fixes typo.