### PR TITLE
fix: running for current latest jina

### DIFF
--- a/southpark-search/README.md
+++ b/southpark-search/README.md
@@ -423,7 +423,7 @@ metas:
 
 ```
 
-Just like the `doc_indexer`, the `chunk_indexer` has different behaviors for different requests. For the `IndexRequest`, the `chunk_indexer` uses three Drivers in serial, namely, `VectorIndexDriver`, `PruneDriver`, and `KVIndexDriver`. The idea is to first use `VectorIndexDriver` to call the `index()` function from the `NumpyIndexer` so that the vectors for all the Chunks are indexed. Then the `PruneDriver` prunes the message, and the `KVIndexDriver` calls the `index()` function from the `BasePbIndexer`. This behavior is defined in the `executor` field.
+Just like the `doc_indexer`, the `chunk_indexer` has different behaviors for different requests. For the `IndexRequest`, the `chunk_indexer` uses three Drivers in serial, namely, `VectorIndexDriver`, `PruneDriver`, and `KVIndexDriver`. The idea is to first use `VectorIndexDriver` to call the `index()` function from the `NumpyIndexer` so that the vectors for all the Chunks are indexed. Then the `PruneDriver` prunes the message, and the `KVIndexDriver` calls the `index()` function from the `BasePbIndexer`. This behavior is defined in the `executor` field. The `requests?` field is not needed from jina 0.5.5 onwards but still needed in jina 0.5.4.
 
 ```yaml
 requests:

--- a/southpark-search/pods/index-chunk.yml
+++ b/southpark-search/pods/index-chunk.yml
@@ -16,3 +16,31 @@ components:
 metas:
   name: chunk_indexer
   workspace: $JINA_WORKSPACE
+requests:
+  on:
+    SearchRequest:
+      - !VectorSearchDriver
+        with:
+          executor: BaseVectorIndexer
+      - !ExcludeQL
+        with:
+          fields:
+            - embedding
+      - !KVSearchDriver
+        with:
+          executor: BaseKVIndexer
+          granularity_range: [0, 0]
+          adjacency_range: [0, 1]
+    IndexRequest:
+      - !VectorIndexDriver
+        with:
+          executor: BaseVectorIndexer
+      - !ExcludeQL
+        with:
+          fields:
+            - embedding
+      - !KVIndexDriver
+        with:
+          executor: BaseKVIndexer
+    ControlRequest:
+      - !ControlReqDriver {}

--- a/southpark-search/requirements.txt
+++ b/southpark-search/requirements.txt
@@ -1,4 +1,4 @@
 click
 transformers
 torch
-jina[scipy]==0.5.5
+jina[scipy]==0.5.4


### PR DESCRIPTION
This should make the example run for jina 0.5.4. The changes can be reverted, once 0.5.5 is published.