### PR TITLE
fix: southpark working again

### DIFF
--- a/southpark-search/flow-index.yml
+++ b/southpark-search/flow-index.yml
@@ -6,12 +6,5 @@ pods:
     uses: pods/encode.yml
     timeout_ready: 1200000
     read_only: true
-  chunk_indexer:
-    uses: pods/index-chunk.yml
-  doc_indexer:
-    uses: pods/index-doc.yml
-    needs: extractor
-  join_all:
-    uses: _merge
-    needs: [doc_indexer, chunk_indexer]
-    read_only: true
+  indexer:
+    uses: pods/index.yml

--- a/southpark-search/flow-query.yml
+++ b/southpark-search/flow-query.yml
@@ -7,9 +7,7 @@ pods:
     uses: pods/encode.yml
     timeout_ready: 60000
     read_only: true
-  chunk_indexer:
-    uses: pods/index-chunk.yml
+  indexer:
+    uses: pods/index.yml
     polling: all
     uses_reducing: _merge_all
-  doc_indexer:
-    uses: pods/index-doc.yml

--- a/southpark-search/pods/index-doc.yml
+++ b/southpark-search/pods/index-doc.yml
@@ -1,6 +1,0 @@
-!BinaryPbIndexer
-with:
-  index_filename: doc.gzip
-metas:
-  name: doc_indexer
-  workspace: $JINA_WORKSPACE

--- a/southpark-search/pods/index.yml
+++ b/southpark-search/pods/index.yml
@@ -9,10 +9,10 @@ components:
       workspace: $JINA_WORKSPACE
   - !BinaryPbIndexer
     with:
-      index_filename: chunk.gz
+      index_filename: doc.gz
     metas:
-      name: chunkidx  # a customized name
+      name: docidx  # a customized name
       workspace: $JINA_WORKSPACE
 metas:
-  name: chunk_indexer
+  name: indexer
   workspace: $JINA_WORKSPACE


### PR DESCRIPTION
Adapting the example for `traversal_paths` implementation.

On the way making the example really slim, since there weren't any chunks, no chunk indexing is needed. Anyhow, that quality was better with jina `0.5.5` and I don't know why.