### PR TITLE
fix: fashion example traversal tree ready

### DIFF
--- a/fashion-example-query/fashion/app.py
+++ b/fashion-example-query/fashion/app.py
@@ -136,7 +136,7 @@ def query_generator(num_doc, target):
 def index(num_doc, target):
     f = Flow.load_config('flow-index.yml')
     with f:
-        f.index(index_generator(num_doc, target), batch_size=32)
+        f.index(index_generator(num_doc, target), batch_size=2048)
 
 
 def query(num_doc, target):

--- a/fashion-example-query/fashion/index/indexer-ankleboot.yml
+++ b/fashion-example-query/fashion/index/indexer-ankleboot.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-bag.yml
+++ b/fashion-example-query/fashion/index/indexer-bag.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-coat.yml
+++ b/fashion-example-query/fashion/index/indexer-coat.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-dress.yml
+++ b/fashion-example-query/fashion/index/indexer-dress.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-pullover.yml
+++ b/fashion-example-query/fashion/index/indexer-pullover.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-sandal.yml
+++ b/fashion-example-query/fashion/index/indexer-sandal.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-shirt.yml
+++ b/fashion-example-query/fashion/index/indexer-shirt.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-sneaker.yml
+++ b/fashion-example-query/fashion/index/indexer-sneaker.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-trouser.yml
+++ b/fashion-example-query/fashion/index/indexer-trouser.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/indexer-tshirt.yml
+++ b/fashion-example-query/fashion/index/indexer-tshirt.yml
@@ -42,6 +42,4 @@ requests:
       - !KVSearchDriver
         with:
           executor: chunkidx
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']

--- a/fashion-example-query/fashion/index/reduce.yml
+++ b/fashion-example-query/fashion/index/reduce.yml
@@ -7,22 +7,16 @@ requests:
     [SearchRequest]:
       - !ReduceAllDriver
         with:
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          traversal_paths: ['m']
       - !SortQL
         with:
           reverse: true
-          field: 'score.value'
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          field: 'score__value'
+          traversal_paths: ['m']
       - !SliceQL
         with:
           start: 0
-          end: 50
-          granularity_range: [0, 0]
-          adjacency_range: [1, 1]
-          recur_on: matches
+          end: 20
+          traversal_paths: ['m']
     ControlRequest:
       - !ControlReqDriver {}

--- a/fashion-example-query/fashion/requirements.txt
+++ b/fashion-example-query/fashion/requirements.txt
@@ -1,1 +1,1 @@
-jina[devel,torch,tensorflow,transformers]==0.5.5
+jina[devel,torch,tensorflow,transformers]==0.6.4


### PR DESCRIPTION
This will fix the fashion-example, once jina `0.6.4` is released.