### PR TITLE
Fix: Email newsletter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Learn to how to use SOTA visual representation for searching Pokémon!
 ## Community
 
 - [Slack channel](https://join.slack.com/t/jina-ai/shared_invite/zt-dkl7x8p0-rVCv~3Fdc3~Dpwx7T7XG8w) - a communication platform for developers to discuss Jina
-- [Community newsletter](mailto:newsletter+subscribe@jina.ai) - subscribe to the latest update, release and event news of Jina
+- [Community newsletter](https://jina.us17.list-manage.com/subscribe/post?u=135040dff373660039d95c86c&id=6873344704) - subscribe to the latest update, release and event news of Jina
 - [LinkedIn](https://www.linkedin.com/company/jinaai/) - get to know Jina AI as a company and find job opportunities
 - [![Twitter Follow](https://img.shields.io/twitter/follow/JinaAI_?label=Follow%20%40JinaAI_&style=social)](https://twitter.com/JinaAI_) - follow us and interact with us using hashtag `#JinaSearch`  
 - [Company](https://jina.ai) - know more about our company, we are fully committed to open-source!


### PR DESCRIPTION
Currently the email link points to an email address, I assume it would be better to point directly to mailchimp signup as the main website does?