### PR TITLE
refactor: adapted tests to the jina style of testing

### DIFF
--- a/southpark-search/tests/test_southparksearch.py
+++ b/southpark-search/tests/test_southparksearch.py
@@ -6,27 +6,20 @@ import pytest
 import json
 import os
 import sys
-import shutil
 import subprocess
 
 from jina.flow import Flow
 
-os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
-
-num_docs = 100
-top_k = 3
-index_flow_file_path = "flow-index.yml"
-query_flow_file_path = "flow-query.yml"
+NUM_DOCS = 100
+TOP_K = 3
+INDEX_FLOW_FILE_PATH = "flow-index.yml"
+QUERY_FLOW_FILE_PATH = "flow-query.yml"
 
 
-def config():
+def config(tmpdir):
     os.environ["JINA_DATA_FILE"] = os.environ.get("JINA_DATA_FILE", "tests/data-index.csv")
-    os.environ["JINA_WORKSPACE"] = os.environ.get("JINA_WORKSPACE", "workspace")
+    os.environ["JINA_WORKSPACE"] = os.environ.get("JINA_WORKSPACE", str(tmpdir))
     os.environ["JINA_PORT"] = os.environ.get("JINA_PORT", str(45678))
-
-
-def prepare_data():
-    pass
 
 
 def setup_env():
@@ -35,27 +28,28 @@ def setup_env():
 
 
 def index_documents():
-    f = Flow().load_config(index_flow_file_path)
+    f = Flow().load_config(INDEX_FLOW_FILE_PATH)
 
     with f:
         f.index_lines(filepath=os.environ["JINA_DATA_FILE"],
                       batch_size=8,
-                      size=num_docs)
+                      size=NUM_DOCS)
 
 
-def call(method, url, payload=None, headers={'Content-Type': 'application/json'}):
+def call_api(url, payload=None, headers={'Content-Type': 'application/json'}):
     import requests
-    return getattr(getattr(requests, method)(url, data=json.dumps(payload), headers=headers), 'json')()
+    return requests.post(url, data=json.dumps(payload), headers=headers).json()
 
 
-def get_results(query, top_k=top_k):
-    return call('post',
-                'http://0.0.0.0:45678/api/search',
-                payload={"top_k": top_k, "mode": "search", "data": [f"text:{query}"]})
+def get_results(query, top_k=TOP_K):
+    return call_api(
+        'http://0.0.0.0:45678/api/search',
+        payload={"top_k": TOP_K, "mode": "search", "data": [f"text:{query}"]}
+    )
 
 
 def set_flow():
-    f = Flow().load_config(query_flow_file_path)
+    f = Flow().load_config(QUERY_FLOW_FILE_PATH)
     f.use_rest_gateway()
     return f
 
@@ -68,22 +62,17 @@ def queries():
             ("Ill watch that game", ["Check that: I'll watch that game.\n", 'Quit it\n', 'Sorry\n'])]
 
 
-def test_query(queries):
-    config()
+def test_query(queries, tmpdir):
+    config(tmpdir)
     setup_env()
-    prepare_data()
     index_documents()
     f = set_flow()
     with f:
         for query, exp_result in queries:
             output = get_results(query)
             matches = output['search']['docs'][0]['matches']
-            assert len(matches) == top_k  # check the number of docs returned
+            assert len(matches) == TOP_K  # check the number of docs returned
             result = []
             for match in matches:
                 result.append(match['text'])
             assert result == exp_result
-
-
-def test_cleanup():
-    shutil.rmtree(os.environ['JINA_WORKSPACE'])


### PR DESCRIPTION
Some refactoring of the test:

- constants should be upper cased
- there is no need to use `getattr` here and make code complicated
- use pytest native `tmpdir` fixture