### PR TITLE
fix: made docker-compose file slimmer

### DIFF
--- a/southpark-search/tests/distributed/docker-compose.yml
+++ b/southpark-search/tests/distributed/docker-compose.yml
@@ -1,37 +1,32 @@
 version: "3.8"
 services:
-  encoder-pod:
+  flow:
     image: south
     build:
       context: .
       dockerfile: tests/distributed/Dockerfile
-    expose:
-      - 8000
-      - 10000-60000
-    environment:
-      - JINAD_CONTEXT=pod
-    env_file:
-      - tests/distributed/.env
-    links:
-      - index-pod:${JINA_INDEX_HOST}
-  index-pod:
-    image: south
-    expose:
-      - 8000
-      - 10000-60000
-    environment:
-      - JINAD_CONTEXT=pod
-    env_file:
-      - tests/distributed/.env
-  flow:
-    image: south
     ports:
       - "8000:8000"
       - "45678:45678"
     env_file:
       - tests/distributed/.env
-    links:
-      - encoder-pod:${JINA_ENCODER_HOST}
-      - index-pod:${JINA_INDEX_HOST}
     expose:
       - 10000-60000
+  encoder:
+    image: south
+    expose:
+      - 8000
+      - 10000-60000
+    environment:
+      - JINAD_CONTEXT=pod
+    env_file:
+      - tests/distributed/.env
+  index:
+    image: south
+    expose:
+      - 8000
+      - 10000-60000
+    environment:
+      - JINAD_CONTEXT=pod
+    env_file:
+      - tests/distributed/.env


### PR DESCRIPTION
removed the linking, since it automatically happens by container name in latest docker-version. `links` is deprecated by docker-compose.