### PR TITLE
fix: transformers version in lyrics fixed

### DIFF
--- a/multires-lyrics-search/requirements.txt
+++ b/multires-lyrics-search/requirements.txt
@@ -1,5 +1,5 @@
 jina[hub,http]==0.7.4
-torch
-transformers
+torch==1.7.0
+transformers==3.5.1
 requests~=2.24
-pytest
+pytest==6.1.2


### PR DESCRIPTION
There is a new version (`4.0.0`) of `transformers` release which breaks our current interface to transformers. thus, I fixed the version to `3.5.1`.