### PR TITLE
older version of jina is not compatible with the newer version of doc…

### DIFF
--- a/flower-search/requirements.txt
+++ b/flower-search/requirements.txt
@@ -2,4 +2,5 @@ click
 pillow
 torch
 jina[devel]==0.4.1
+docker==4.3.0
 


### PR DESCRIPTION
jina v0.4.1 is not compatible with the docker 4.4.0 , downgrading the docker sdk to 4.3.0 seems to be working fine.