### PR TITLE
fix(flower-search): updated url for 17flowers data set

### DIFF
--- a/flower-search/get_data.sh
+++ b/flower-search/get_data.sh
@@ -2,5 +2,5 @@
 TEST_WORKDIR=/tmp/jina/flower/
 mkdir -p ${TEST_WORKDIR}
 cd ${TEST_WORKDIR}
-curl http://www.robots.ox.ac.uk/~vgg/data/flowers/17/17flowers.tgz --output 17flowers.tgz
+curl https://www.robots.ox.ac.uk/~vgg/data/flowers/17/17flowers.tgz --output 17flowers.tgz
 tar zxf 17flowers.tgz


### PR DESCRIPTION
updated url for 17flowers data set. Otherwise get_data fails.

UPD:
The old URL works, but it downloads a redirect page, then tar command fails.

```
$ curl http://www.robots.ox.ac.uk/~vgg/data/flowers/17/17flowers.tgz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://www.robots.ox.ac.uk/~vgg/data/flowers/17/17flowers.tgz">here</a>.</p>
</body></html>
```