### PR TITLE
docs: examples readme overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,130 +128,68 @@ First a little light background reading, and then let's jump in and build our fi
   </tr>
 </table>
 
-## Cross Modal Search
+## 🕊️ /Advanced Examples
 
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/cross-modal-search">Search images from captions and vice-versa</a></h4>
-Use one modality (text) to search another (images)
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🕊</h3></td>
-</tr>
-
+<table>
+  <tr>
+    <td>
+      <h1>🖼️📄</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/cross-modal-search">Cross Modal: Search images from captions and vice-versa</a></h4>
+      Use one modality (text) to search another (images)
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🖼️📄</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/multimodal-search-tirg">Multi-Modal: Search images with 2 modalities in the query</a></h4>
+      Use more than one modality (image+text) to search images
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🖼️</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/fashion-example-query">Build complex logic, structures and filters with Query Language</a></h4>
+      Create separate indexes and queries for different clothing in Fashion-MNIST
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🖼️</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/faiss-search">Index and query with FAISS</a></h4>
+      Build a vector search engine that finds the closest vector in the database to a query.
+    </td>
+  </tr>
 </table>
 
-## Multi Modal Search
+## Useful Docs
 
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
+<table>
 <tr>
 <td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/multimodal-search-tirg">Search images with 2 modalities in the query</a></h4>
-Use more than one modality (image+text) to search images
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<h5>Performance and Scalability</h5>
 </td>
-<td><h3>🕊</h3></td>
-</tr>
-
-</table>
-
-## Miscellaneous
-
-<table width=100% style='width: 100%'>
-
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
 <td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/fashion-example-query">Build complex logic, structures and filters with Query Language</a></h4>
-Create separate indexes and queries for different clothing in Fashion-MNIST
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+- <a href="https://docs.jina.ai/chapters/remote/index.html">Distribute Your Workflow Remotely</a>
+- <a href="https://docs.jina.ai/chapters/hub/index.html">Run Jina Pod in Docker Containers</a>
 </td>
-<td><h3>🐣</h3></td>
-</tr>
-
-</table>
-
-## Improve Performance and Scalability
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
 </tr>
 <tr>
 <td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Video Semantic Search in Scale with Prefetching and Sharding</a></h4>
-Increase performance by using prefetching and sharding
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<h5>Extend and Share Jina</h5>
 </td>
-<td><h3>🕊</h3></td>
-</tr>
-
-<tr>
 <td>
-<h4><a href="https://docs.jina.ai/chapters/remote/index.html">Distribute Your Workflow Remotely</a></h4>
-Run Jina on remote instances and distribute your workflow
+- <a href="https://docs.jina.ai/chapters/extend/executor.html">Extend Jina by Implementing Your Own Executor</a>
+- <a href="https://github.com/jina-ai/jina-hub#publish-your-pod-image-to-jina-hub">Share Your Extension with the World</a>
 </td>
-<td><h3>🕊</h3></td>
 </tr>
-
-<tr>
-<td>
-<h4><a href="https://docs.jina.ai/chapters/hub/index.html">Run Jina Pod via Docker Container</a></h4>
-Learn how Jina solves complex dependencies easily with Docker container
-</td>
-<td><h3>🕊</h3></td>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/faiss-search">Index and query with FAISS</a></h4>
-Build a vector search engine that finds the closest vector in the database to a query.
-</td>
-<td><h3>🚀</h3></td>
-</tr>
-
-</table>
-
-## Extend and Share Jina
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-<tr>
-<td>
-<h4><a href="https://docs.jina.ai/chapters/extend/executor.html">Extend Jina by Implementing Your Own Executor</a></h4>
-Implement your own ideas into Jina's plugin
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🕊</h3></td>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/jina-hub#publish-your-pod-image-to-jina-hub">Share Your Extension with the World</a></h4>
-Use Jina Hub and share your extensions with engineers around the globe
-</td>
-<td><h3>🚀</h3></td>
-</tr>
-
 </table>
 
 ## Adding Tests for Examples

--- a/README.md
+++ b/README.md
@@ -21,44 +21,9 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## 🏁 Start Here
+These examples showcase Jina in action and provide sample code for you to work from. We suggest you read [Jina 101](http://101.jina.ai) and <a href="https://jina.ai/2020/07/06/What-is-Neural-Search-and-Why-Should-I-Care.html">What is Neural Search?</a> to get a conceptual overview.
 
-First a little light background reading, and then let's jump in and build our first app!
-
-<table>
-  <tr>
-    <td>
-      <a href="https://jina.ai/2020/07/06/What-is-Neural-Search-and-Why-Should-I-Care.html">
-        <img src="https://miro.medium.com/max/1000/1*czKD1E9fL1ndRGzwjv9Kvg.png", title="What is Neural Search?" alt="What is Neural search?">
-      </a>
-    </td>
-    <td>
-      <h3>
-      <a href="https://jina.ai/2020/07/06/What-is-Neural-Search-and-Why-Should-I-Care.html">
-        What is Neural Search?
-      </a>
-      </h3>
-      <p>AI-powered search with less effort, more flexibility</p>
-    </td>
-  </tr>
-  <tr>
-      <td width="30%">
-    <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101">
-      <img src="https://github.com/jina-ai/jina/blob/master/docs/chapters/101/img/ILLUS12.png?raw=true" alt="Jina 101 Concept Illustration Book, Copyright by Jina AI Limited" title="Jina 101 Concept Illustration Book, Copyright by Jina AI Limited"/>
-    </a>
-    </td>
-    <td width="70%">
-&nbsp;&nbsp;<h3><a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101">Jina 101: First Thing to Learn About Jina</a></h3>
-&nbsp;&nbsp;<a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101">English</a> •
-  <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101/README.ja.md">日本語</a> •
-  <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101/README.fr.md">français</a> •
-  <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101/README.de.md">Deutsch</a> •
-  <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101/README.ru.md">Русский язык</a> •
-  <a href="https://github.com/jina-ai/jina/tree/master/docs/chapters/101/README.zh.md">中文</a>
-    </td>
-
-  </tr>
-</table>
+To learn more about how to use Jina, please refer to [our docs](http://www.jina.ai).
 
 ## 🐣 Simple Examples
 
@@ -169,29 +134,6 @@ First a little light background reading, and then let's jump in and build our fi
   </tr>
 </table>
 
-## Useful Docs
-
-<table>
-<tr>
-<td>
-<h5>Performance and Scalability</h5>
-</td>
-<td>
-<li><a href="https://docs.jina.ai/chapters/remote/index.html">Distribute Your Workflow Remotely</a></li>
-<li><a href="https://docs.jina.ai/chapters/hub/index.html">Run Jina Pod in Docker Containers</a></li>
-</td>
-</tr>
-<tr>
-<td>
-<h5>Extend and Share Jina</h5>
-</td>
-<td>
-<li><a href="https://docs.jina.ai/chapters/extend/executor.html">Extend Jina by Implementing Your Own Executor</a></li>
-<li><a href="https://github.com/jina-ai/jina-hub#publish-your-pod-image-to-jina-hub">Share Your Extension with the World</a></li>
-</td>
-</tr>
-</table>
-
 ## Adding Tests for Examples
 
 You are highly encouraged to add a test for your example so that we will be alerted if it breaks in the future:
@@ -202,7 +144,7 @@ You are highly encouraged to add a test for your example so that we will be aler
 4. Add your example folder name to the `path` variable in `matrix` of `.github/worflows/ci.yml`. This will trigger your example test on creating a pull request.
 
 
-## Tips
+### Testing Tips
 
 - For reference, check out the `tests` folder from [South Park example](https://github.com/jina-ai/examples/tree/master/southpark-search/tests) if your data is about text and [object search example](https://github.com/jina-ai/examples/tree/master/object-search/tests) for images.
 - Try using the original example function by importing them to the test. Avoid any modifications to original Flow or logic.

--- a/README.md
+++ b/README.md
@@ -68,16 +68,23 @@ First a little light background reading, and then let's jump in and build our fi
       <h1>📄</h1>
     </td>
     <td>
-      <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a></h4>
+      Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>📄</h1>
     </td>
     <td>
-      Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a></h4>
+      Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
     </td>
   </tr>
 </table>
 
 - 📄  - 
-- 📄 <a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a> - Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
+- 📄  - 
 - 📄 <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
 - 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!
 - 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a> - Detect, index and query similar objects

--- a/README.md
+++ b/README.md
@@ -62,7 +62,20 @@ First a little light background reading, and then let's jump in and build our fi
 
 ## 🐣 Simple Examples
 
-- 📄 <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a> - Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+<table>
+  <tr>
+    <td>
+      <h1>📄</h1>
+    </td>
+      <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a>
+    <td>
+    <td>
+      Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+    </td>
+  </tr>
+</table>
+
+- 📄  - 
 - 📄 <a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a> - Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
 - 📄 <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
 - 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!

--- a/README.md
+++ b/README.md
@@ -1,15 +1,4 @@
-
 # Examples for Jina
-
-<p align="center">
- 
-[![Jina](https://github.com/jina-ai/jina/blob/master/.github/badges/jina-hello-world-badge.svg "Run Jina 'Hello, World!' without installing anything")](https://github.com/jina-ai/jina#jina-hello-world-)
-[![Jina](https://github.com/jina-ai/jina/blob/master/.github/badges/license-badge.svg "Jina is licensed under Apache-2.0")](#license)
-[![Jina Docs](https://github.com/jina-ai/jina/blob/master/.github/badges/docs-badge.svg "Checkout our docs and learn Jina")](https://docs.jina.ai)
-[![Python 3.7 3.8](https://github.com/jina-ai/jina/blob/master/.github/badges/python-badge.svg "Jina supports Python 3.7 and above")](#)
-[![Docker](https://github.com/jina-ai/jina/blob/master/.github/badges/docker-badge.svg "Jina is multi-arch ready, can run on differnt architectures")](https://hub.docker.com/r/jinaai/jina/tags)
-
-</p>
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ First a little light background reading, and then let's jump in and build our fi
 
 ## 🐣 Simple Examples
 
-- <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a> - Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
-- <a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a> - Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
-- <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
-- <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!
-- <a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a> - Detect, index and query similar objects
-- <a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a> - A demo of neural search for audio data based Vggish model.
-- <a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a> - Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
+- 📄 <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a> - Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+- 📄 <a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a> - Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
+- 📄 <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
+- 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!
+- 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a> - Detect, index and query similar objects
+- 🎧 <a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a> - A demo of neural search for audio data based Vggish model.
+- 🎞️ <a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a> - Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
 
 ## Cross Modal Search
 

--- a/README.md
+++ b/README.md
@@ -81,15 +81,52 @@ First a little light background reading, and then let's jump in and build our fi
       Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
     </td>
   </tr>
+  <tr>
+    <td>
+      <h1>📄</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a></h4>
+      Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🖼️</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a></h4>
+      Use SOTA visual representation for searching Pokémon!
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🖼️</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a></h4>
+      Detect, index and query similar objects
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🎧</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a></h4>
+      A demo of neural search for audio data based Vggish model.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h1>🎞️ </h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a></h4>
+      Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
+    </td>
+  </tr>
 </table>
-
-- 📄  - 
-- 📄  - 
-- 📄 <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
-- 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!
-- 🖼️  <a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a> - Detect, index and query similar objects
-- 🎧 <a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a> - A demo of neural search for audio data based Vggish model.
-- 🎞️ <a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a> - Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
 
 ## Cross Modal Search
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Start Here
+## 🏁 Start Here
 
 First a little light background reading, and then let's jump in and build our first app!
 
@@ -128,9 +128,18 @@ First a little light background reading, and then let's jump in and build our fi
   </tr>
 </table>
 
-## 🕊️ /Advanced Examples
+## 🕊️  Advanced Examples
 
 <table>
+  <tr>
+    <td>
+      <h1>📄</h1>
+    </td>
+    <td>
+      <h4><a href="https://github.com/jina-ai/examples/tree/master/faiss-search">Index and query with FAISS</a></h4>
+      Build a vector search engine that finds the closest vector in the database to a query.
+    </td>
+  </tr>
   <tr>
     <td>
       <h1>🖼️📄</h1>
@@ -151,20 +160,11 @@ First a little light background reading, and then let's jump in and build our fi
   </tr>
   <tr>
     <td>
-      <h1>🖼️</h1>
+      <h1>🗂️</h1>
     </td>
     <td>
       <h4><a href="https://github.com/jina-ai/examples/tree/master/fashion-example-query">Build complex logic, structures and filters with Query Language</a></h4>
       Create separate indexes and queries for different clothing in Fashion-MNIST
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <h1>🖼️</h1>
-    </td>
-    <td>
-      <h4><a href="https://github.com/jina-ai/examples/tree/master/faiss-search">Index and query with FAISS</a></h4>
-      Build a vector search engine that finds the closest vector in the database to a query.
     </td>
   </tr>
 </table>
@@ -177,8 +177,8 @@ First a little light background reading, and then let's jump in and build our fi
 <h5>Performance and Scalability</h5>
 </td>
 <td>
-- <a href="https://docs.jina.ai/chapters/remote/index.html">Distribute Your Workflow Remotely</a>
-- <a href="https://docs.jina.ai/chapters/hub/index.html">Run Jina Pod in Docker Containers</a>
+<li><a href="https://docs.jina.ai/chapters/remote/index.html">Distribute Your Workflow Remotely</a></li>
+<li><a href="https://docs.jina.ai/chapters/hub/index.html">Run Jina Pod in Docker Containers</a></li>
 </td>
 </tr>
 <tr>
@@ -186,8 +186,8 @@ First a little light background reading, and then let's jump in and build our fi
 <h5>Extend and Share Jina</h5>
 </td>
 <td>
-- <a href="https://docs.jina.ai/chapters/extend/executor.html">Extend Jina by Implementing Your Own Executor</a>
-- <a href="https://github.com/jina-ai/jina-hub#publish-your-pod-image-to-jina-hub">Share Your Extension with the World</a>
+<li><a href="https://docs.jina.ai/chapters/extend/executor.html">Extend Jina by Implementing Your Own Executor</a></li>
+<li><a href="https://github.com/jina-ai/jina-hub#publish-your-pod-image-to-jina-hub">Share Your Extension with the World</a></li>
 </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -60,132 +60,15 @@ First a little light background reading, and then let's jump in and build our fi
   </tr>
 </table>
 
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
+## 🐣 Simple Examples
 
-<tr>
-<td width="90%">
-<h4><a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a></h4>
-Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-</table>
-
-## Search Text
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a></h4>
-Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🐣</h3></td>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/multilingual-search">Multilingual semantic search with Laser</a></h4>
-Language-agnostic search on WMTData
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a></h4>
-Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-</table>
-
-
-## Search Images
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a></h4>
-Use SOTA visual representation for searching Pokémon!
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🚀</h3></td>
-</tr>
-
-<tr>
-  <td>
-    <h4>
-      <a href="https://github.com/jina-ai/examples/tree/master/object-search">
-        Object detection with fasterrcnn and MobileNetV2
-      </a>
-    </h4>
-    Detect, index and query similar objects
-  </td>
-  <td><h3>🚀</h3></td>
-</tr>
-
-</table>
-
-## Search Audio
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a></h4>
-A demo of neural search for audio data based Vggish model.
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/audio-search-mfcc">Search audio based on Mel Frequency Cepstral Coefficients</a></h4>
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-</table>
-
-## Search Video
-
-<table width=100% style='width: 100%'>
-<tr>
-<th width="90%" style="width: 90%">Tutorials</th>
-<th width="10%" style="width: 10%">Level</th>
-</tr>
-
-<tr>
-<td>
-<h4><a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a></h4>
-Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-</td>
-<td><h3>🐣</h3></td>
-</tr>
-
-</table>
+- <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a> - Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
+- <a href="https://github.com/jina-ai/examples/tree/master/southpark-search">Build a NLP Semantic Search System with Transformers</a> - Upgrade from plain search to sentence search and practice your Flows and Pods by searching South Park scripts
+- <a href="https://github.com/jina-ai/examples/tree/master/multires-lyrics-search">Search Lyrics with Transformers and PyTorch</a> - Get a better understanding of chunks by searching a lyrics database. Now with shiny front-end!
+- <a href="https://github.com/jina-ai/examples/tree/master/pokedex-with-bit">Google's Big Transfer Model in (Poké-)Production</a> - Use SOTA visual representation for searching Pokémon!
+- <a href="https://github.com/jina-ai/examples/tree/master/object-search">Object detection with fasterrcnn and MobileNetV2</a> - Detect, index and query similar objects
+- <a href="https://github.com/jina-ai/examples/tree/master/audio-search">Search YouTube audio data with Vggish</a> - A demo of neural search for audio data based Vggish model.
+- <a href="https://github.com/jina-ai/examples/tree/master/tumblr-gif-search">Search Tumblr GIFs with KerasEncoder</a> - Use prefetching and sharding to improve the performance of your index and query flow when searching animated GIFs.
 
 ## Cross Modal Search
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ First a little light background reading, and then let's jump in and build our fi
     <td>
       <h1>📄</h1>
     </td>
-      <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a>
     <td>
+      <a href="https://github.com/jina-ai/examples/tree/master/my-first-jina-app">My First Jina App</a>
+    </td>
     <td>
       Brand new to neural search? Not for long! Use cookiecutter to search through Star Trek scripts using Jina
     </td>


### PR DESCRIPTION
Based on results of discussions, I've cut many examples from the readme and re-organized. Also general tidying up and structuring

- docs(readme): slim down, revamp into simple-advanced
- docs(readme): modality emoji
- docs(readme): table test
- docs(readme): table fix
- docs(readme): table style
- docs(readme): simple example table done
- docs(readme): advanced/docs tables done
- docs(readme): emojis, reorder, fix doc bullets
- docs(readme): condense 101, what is neural search; replace docs table with link; clearer headings
