### PR TITLE
fix: ignore dirs for models downloaded via script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ jina-profile*.json
 */workspace
 
 models
+result.html # genreated in pokedex example

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ jina-profile*.json
 
 .vscode/
 */workspace
+
+models


### PR DESCRIPTION
Some examples use scripts to download their model (like audio search). We shouldn't upload those to our repo.
