### PR TITLE
fix: add docker to requirements.txt

### DIFF
--- a/advanced-vector-search/requirements.txt
+++ b/advanced-vector-search/requirements.txt
@@ -1,2 +1,3 @@
+docker
 click
 jina


### PR DESCRIPTION
Added docker to requirements.txt to enable the usage of annoy or faiss from their docker images.