### PR TITLE
refactor: prepare example to host 1M docs

### DIFF
--- a/advanced-vector-search/Dockerfile
+++ b/advanced-vector-search/Dockerfile
@@ -1,4 +1,3 @@
-# annoy indexer has some more complex dependencies
 FROM jinaai/jina
 
 # setup the workspace
@@ -6,17 +5,20 @@ COPY . /workspace
 WORKDIR /workspace
 
 # uninstall jina so that jina[hub] installs everything with Faiss and Annoy
-
 RUN apt-get update && apt-get install --no-install-recommends -y curl gcc build-essential \
     && pip uninstall -y jina \
     && pip install -r requirements.txt && pip install -r faiss-requirements.txt && pip install -r annoy-requirements.txt
 
 ENV JINA_USES_FAISS='yaml/hub-faiss-indexer.yml'
 ENV JINA_USES_ANNOY='yaml/hub-annoy-indexer.yml'
+ENV JINA_DATASET_NAME='sift'
+ENV JINA_SHARDS=4
+ENV REQUEST_SIZE=1000
+ENV OMP_NUM_THREADS=1
 
-RUN ./get_siftsmall.sh && ./generate_training_data.sh
+RUN ./get_data.sh sift && ./generate_training_data.sh && python app.py -t index
 
-RUN python app.py -t index
+ENV REQUEST_SIZE=100
 
 ENTRYPOINT ["./entrypoint.sh", "faiss"]
 
@@ -24,7 +26,7 @@ LABEL author="Jina AI Dev-Team (dev-team@jina.ai)"
 LABEL type="app"
 LABEL kind="example"
 LABEL avatar="None"
-LABEL description="Jina App using Faiss and Annoy to search in SIFT_128_ANN dataset preindexed with jina"
+LABEL description="Jina App using Faiss and Annoy to search in SIFT dataset preindexed with jina"
 LABEL documentation="https://github.com/jina-ai/examples/tree/master/advanced-vector-search"
 LABEL keywords="[examples, faiss, annoy, ANN]"
 LABEL license="apache-2.0"
@@ -33,4 +35,4 @@ LABEL platform="linux/amd64"
 LABEL update="None"
 LABEL url="https://github.com/jina-ai/examples/tree/master/advanced-vector-search"
 LABEL vendor="Jina AI Limited"
-LABEL version="0.0.1"
+LABEL version="0.0.2"

--- a/advanced-vector-search/README.md
+++ b/advanced-vector-search/README.md
@@ -27,7 +27,7 @@ This example is prepared to use one of these 2 datasets [ANN_SIFT10K or ANN_SIFT
 To run the local example, we show here the steps to work with ANN_SIFT10K (siftsmall). A [docker image](https://hub.docker.com/r/jinahub/app.example.advancedvectorsearch) is published where the ANN_SIFT1M (sift) has already been indexed
 using 4 shards.
   
-These vectors are [SIFT](https://en.wikipedia.org/wiki/Scale-invariant_feature_transform) descriptors for some image dataset. The example is easily adapted for use with larger datasets from the same source which can be found [here](http://corpus-texmex.irisa.fr/). For this demo, a vector is considered to be a document.
+These vectors are [SIFT](https://en.wikipedia.org/wiki/Scale-invariant_feature_transform) descriptors for some image dataset. The example is easily adapted for use with larger datasets from the same source which can be found [here](http://corpus-texmex.irisa.fr/). For this demo, a vector is considered to be a Document.
 
 In this example, we use [Faiss](https://hub.docker.com/r/jinahub/pod.indexer.faissindexer) and [Annoy](https://hub.docker.com/r/jinahub/pod.indexer.annoyindexer) Indexer Vectors from the hub.
 

--- a/advanced-vector-search/README.md
+++ b/advanced-vector-search/README.md
@@ -18,15 +18,18 @@
 
 In this demo, we use Jina to build a vector search engine that finds the closest vector in the database to a query
 
-This example uses [ANN_SIFT10K](http://corpus-texmex.irisa.fr/), which is a dataset comprised of three vector sets:  
+This example is prepared to use one of these 2 datasets [ANN_SIFT10K or ANN_SIFT1M](http://corpus-texmex.irisa.fr/), which are datasets comprised of three vector sets:  
 
-- 10K index
-- 100 vectors query
-- 25K vectors to train
+- 10K or 1M index
+- 100 or 10K vectors query
+- 25K or 100k vectors to train
+
+To run the local example, we show here the steps to work with ANN_SIFT10K (siftsmall). A [docker image](https://hub.docker.com/r/jinahub/app.example.advancedvectorsearch) is published where the ANN_SIFT1M (sift) has already been indexed
+using 4 shards.
   
-These vectors are [SIFT](https://en.wikipedia.org/wiki/Scale-invariant_feature_transform) descriptors for some image dataset. The example is easily adapted for use with larger datasets from the same source which can be found [here](http://corpus-texmex.irisa.fr/). For this demo, a vector is considered to be a document and only one chunk per document is used.
+These vectors are [SIFT](https://en.wikipedia.org/wiki/Scale-invariant_feature_transform) descriptors for some image dataset. The example is easily adapted for use with larger datasets from the same source which can be found [here](http://corpus-texmex.irisa.fr/). For this demo, a vector is considered to be a document.
 
-In this example, we use Faiss and Annoy Indexer Vectors from the hub (https://hub.docker.com/r/jinahub/pod.indexer.faissindexer) (https://hub.docker.com/r/jinahub/pod.indexer.annoyindexer).
+In this example, we use [Faiss](https://hub.docker.com/r/jinahub/pod.indexer.faissindexer) and [Annoy](https://hub.docker.com/r/jinahub/pod.indexer.annoyindexer) Indexer Vectors from the hub.
 
 This example will show how the same index created with an index Flow can be used to be queried using different type of indexers.
 
@@ -57,16 +60,17 @@ We encourage you to try different indexers and different options for other index
 ## Requirements
 
 Be sure to create an environment with Python 3.7 or higher installed, then you also need to have the requirements of this example,
-which is `jina` and `click`.
+which are `jina`, `docker` and `click`.
 
-In order to run the example with the different indexers, make sure to pull the docker images from the [Jina Hub repository] (https://hub.docker.com/u/jinahub)
+In order to run the example with the different indexers, make sure to pull the docker images from the [Jina Hub repository](https://hub.docker.com/u/jinahub)
 
 ## Prepare the data
 
 In order to get the data needed to run the example, we have prepared a small script that will download the required fails.
+In this e
 
 ```bash
-./get_siftsmall.sh
+./get_data.sh siftsmall
 ```
 
 Moreover, FAISS needs to learn some structural patterns of the data in order to build an efficient indexing scheme. Usually, the training is done with some subset of data that is not necessarily part of the index.
@@ -88,7 +92,6 @@ This workspace folder will contain the built index once the vectors are indexed 
 
 To index the data we first need to define our **Flow** and for this example we'll use a **YAML** file. In the Flow YAML file, we add **Pods** in sequence. In this demo, we have five pods defined:
 
-- `crafter`
 - `encoder`
 - `indexer`
 
@@ -104,16 +107,16 @@ However, we have another Pod working in silence. Actually, the input to the very
 
 ```yaml
 !Flow
-metas:
-  prefetch: 10
+version: '1'
 pods:
-  encoder:
+  - name: encoder
     uses: yaml/encode.yml
-    parallel: $JINA_PARALLEL
-  indexer:
+    shards: $JINA_PARALLEL
+  - name: indexer
     uses: yaml/indexer.yml
-    parallel: $JINA_PARALLEL
+    shards: $JINA_SHARDS
     timeout_ready: 10000
+    polling: any
 ```
 </sub>
 </td>
@@ -135,22 +138,42 @@ to the index flow but with an extra pod used to evaluate results.
 
 ```yaml
 !Flow
+version: '1'
+env:
+  OMP_NUM_THREADS: ${{OMP_NUM_THREADS}}
 with:
   read_only: true
 pods:
-  encoder:
+  - name: encoder
+    show_exc_info: true
     uses: yaml/encode.yml
-    parallel: $JINA_PARALLEL
-  indexer:
+    shards: $JINA_PARALLEL
+  - name: indexer
+    polling: all
+    show_exc_info: true
     uses: $JINA_USES
     uses_internal: $JINA_USES_INTERNAL
-    parallel: $JINA_PARALLEL
-    timeout_ready: 600000
-    #uses_after: _merge_matches  # uncomment this if you want to increase parallelization
-    volumes: './workspace:/workspace/workspace'
-  evaluate:
+    shards: $JINA_SHARDS
+    timeout_ready: -1
+    uses_after: yaml/merge-matches-sort.yml
+    volumes: './workspace:/docker-workspace'
+    remove_uses_ba: true
+    docker_kwargs:
+      environment:
+        JINA_FAISS_INDEX_KEY: $JINA_FAISS_INDEX_KEY
+        JINA_FAISS_DISTANCE: $JINA_FAISS_DISTANCE
+        JINA_FAISS_NORMALIZE: $JINA_FAISS_NORMALIZE
+        JINA_FAISS_NPROBE: $JINA_FAISS_NPROBE
+        JINA_ANNOY_METRIC: $JINA_ANNOY_METRIC
+        JINA_ANNOY_NTREES: $JINA_ANNOY_NTREES
+        JINA_ANNOY_SEARCH_K: $JINA_ANNOY_SEARCH_K
+        OMP_NUM_THREADS: ${{OMP_NUM_THREADS}}
+  - name: evaluate
+    show_exc_info: true
     uses: yaml/evaluate.yml
 ```
+
+All the `environment` variables are added so that it is easy for the user to try out different configurations of `annoy` or `faiss` indexers.
 
 </sub>
 
@@ -167,7 +190,7 @@ In this Flow, the `faiss_indexer` is the one that will do the nearest neighbours
 Index is run with the following command, where batch_size can be chosen by the user. Indexing reads a file of numpy arrays, and sends them to the flow gateway in binary mode to be converted back into numpy arrays by the crafter.
 
 ```bash
-python app.py -t index -n $batch_size
+python app.py -t index
 ```
 
 ### Query <!-- omit in toc -->
@@ -205,24 +228,41 @@ It can be good to look for different parameters to guarantee the best results
 
 ## Use Docker image from the jina hub
 
-To make it easier for the user, we have built and published the [Docker image](https://hub.docker.com/r/jinahub/app.example.advancedvectorsearch) with the indexed documents.
+To make it easier for the user, we have built and published the [Docker image](https://hub.docker.com/r/jinahub/app.example.advancedvectorsearch) with the ANN_SIFT1M dataset indexed.
 You can retrieve the docker image using:
 
 ```bash
-docker pull jinahub/app.example.advancedvectorsearch:0.0.1-0.9.17
+docker pull jinahub/app.example.advancedvectorsearch:0.0.2-0.9.20
 ```
 So you can pull from its latest tags. And you can run it. By default it runs the search with `faiss` indexer. 
 
 To simply run it, please do:
 ```bash
-docker run jinahub/app.example.advancedvectorsearch:0.0.1-0.9.17
+docker run jinahub/app.example.advancedvectorsearch:0.0.2-0.9.20
 ```
 
 If you want to run the image with `annoy` as a search library, you can override the entrypoint doing:
 
 ```bash
-docker run -it --entrypoint=/bin/bash jinahub/app.example.advancedvectorsearch:0.0.1-0.9.17 entrypoint.sh annoy
+docker run -it --entrypoint=/bin/bash jinahub/app.example.advancedvectorsearch:0.0.2-0.9.20 entrypoint.sh annoy
 ```
+
+If you want to change the parameters or of the `Faiss` or the `Annoy` Indexer you can pass different environment variables
+to the `docker run` command by doing for instance:
+
+```bash
+docker run -e JINA_FAISS_INDEX_KEY='Flat' jinahub/app.example.advancedvectorsearch:0.0.2-0.9.20
+```
+
+An important parameter to set is `JINA_DISTANCE_REVERSE`, depending on the type of distance or metric that is used. For instance
+for `inner_product` distance, `JINA_DISTANCE_REVERSE` should be set to True as the returned measure is similarity for `Faiss` and not
+`distance`. Therefore the results should be scores in descending order.
+
+Another parameter that cannot be found int the `init` arguments of `FaissIndexer` or `AnnoyIndexer` is `OMP_NUM_THREADS` that 
+controls how many threads are used by `Faiss` when doing queries. Since the image has been built with 4 shards (around 250K documents each),
+the `OMP_NUM_THREADS` is set to 1 by default to have the example use 4 CPUs. You can try to change also this parameter to investigate
+the quality and speed of the results.
+
 
 ## Wrap up
 

--- a/advanced-vector-search/flow-index.yml
+++ b/advanced-vector-search/flow-index.yml
@@ -3,8 +3,9 @@ version: '1'
 pods:
   - name: encoder
     uses: yaml/encode.yml
-    parallel: $JINA_PARALLEL
+    shards: $JINA_PARALLEL
   - name: indexer
     uses: yaml/indexer.yml
-    parallel: $JINA_PARALLEL
+    shards: $JINA_SHARDS
     timeout_ready: 10000
+    polling: any

--- a/advanced-vector-search/flow-query.yml
+++ b/advanced-vector-search/flow-query.yml
@@ -1,20 +1,34 @@
 !Flow
 version: '1'
+env:
+  OMP_NUM_THREADS: ${{OMP_NUM_THREADS}}
 with:
   read_only: true
 pods:
   - name: encoder
     show_exc_info: true
     uses: yaml/encode.yml
-    parallel: $JINA_PARALLEL
+    shards: $JINA_PARALLEL
   - name: indexer
+    polling: all
     show_exc_info: true
     uses: $JINA_USES
     uses_internal: $JINA_USES_INTERNAL
-    parallel: $JINA_PARALLEL
+    shards: $JINA_SHARDS
     timeout_ready: -1
-    #uses_after: _merge_matches  # uncomment this if you want to increase parallelization
-    volumes: './workspace:/workspace/workspace'
+    uses_after: yaml/merge-matches-sort.yml
+    volumes: './workspace:/docker-workspace'
+    remove_uses_ba: true
+    docker_kwargs:
+      environment:
+        JINA_FAISS_INDEX_KEY: $JINA_FAISS_INDEX_KEY
+        JINA_FAISS_DISTANCE: $JINA_FAISS_DISTANCE
+        JINA_FAISS_NORMALIZE: $JINA_FAISS_NORMALIZE
+        JINA_FAISS_NPROBE: $JINA_FAISS_NPROBE
+        JINA_ANNOY_METRIC: $JINA_ANNOY_METRIC
+        JINA_ANNOY_NTREES: $JINA_ANNOY_NTREES
+        JINA_ANNOY_SEARCH_K: $JINA_ANNOY_SEARCH_K
+        OMP_NUM_THREADS: ${{OMP_NUM_THREADS}}
   - name: evaluate
     show_exc_info: true
     uses: yaml/evaluate.yml

--- a/advanced-vector-search/generate_training_data.py
+++ b/advanced-vector-search/generate_training_data.py
@@ -1,13 +1,18 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import gzip
 import os
+
 from read_vectors_files import fvecs_read
 
-os.environ['JINA_TMP_DATA_DIR'] = './siftsmall'
+os.environ['JINA_DATASET_NAME'] = os.environ.get('JINA_DATASET_NAME', 'siftsmall')
+os.environ['JINA_TMP_DATA_DIR'] = os.environ.get('JINA_TMP_DATA_DIR', './')
+dataset_name = os.environ['JINA_DATASET_NAME']
+tmp_data_dir = os.environ['JINA_TMP_DATA_DIR']
+data_dir = os.path.join(tmp_data_dir, dataset_name)
 train_filepath = 'workspace/train.tgz'
-train_fvecs_path = os.path.join(os.environ['JINA_TMP_DATA_DIR'], 'siftsmall_learn.fvecs')
+train_fvecs_path = os.path.join(data_dir, f'{dataset_name}_learn.fvecs')
 train_data = fvecs_read(train_fvecs_path)
 with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
     f.write(train_data.tobytes())

--- a/advanced-vector-search/get_data.sh
+++ b/advanced-vector-search/get_data.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+curl ftp://ftp.irisa.fr/local/texmex/corpus/${1}.tar.gz --output ${1}.tar.gz
+tar zxf ${1}.tar.gz
+rm -f ${1}.tar.gz

--- a/advanced-vector-search/get_siftsmall.sh
+++ b/advanced-vector-search/get_siftsmall.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-curl ftp://ftp.irisa.fr/local/texmex/corpus/siftsmall.tar.gz --output siftsmall.tar.gz
-tar zxf siftsmall.tar.gz

--- a/advanced-vector-search/read_vectors_files.py
+++ b/advanced-vector-search/read_vectors_files.py
@@ -1,4 +1,4 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import numpy as np

--- a/advanced-vector-search/requirements.txt
+++ b/advanced-vector-search/requirements.txt
@@ -1,4 +1,4 @@
 docker==4.0.1
 click
-jina[hub]==0.9.17
+jina[hub]==0.9.20
 

--- a/advanced-vector-search/yaml/annoy-indexer.yml
+++ b/advanced-vector-search/yaml/annoy-indexer.yml
@@ -3,29 +3,28 @@ components:
   - !AnnoyIndexer
     with:
       index_filename: 'index.gz'
-      n_trees: 10
-      search_k: -1
+      metric: $JINA_ANNOY_METRIC
+      n_trees: $JINA_ANNOY_NTREES
+      search_k: $JINA_ANNOY_SEARCH_K
       ref_indexer:
         !NumpyIndexer
         metas:
-          workspace: '/workspace/workspace'
+          workspace: '/docker-workspace'
           name: wrapidx
         with:
           index_filename: 'index.gz'
     metas:
-      workspace: '/workspace/workspace'
       name: annoyidx
   - !BinaryPbIndexer
     with:
       index_filename: doc.gz
     metas:
       name: docidx
-      workspace: '/workspace/workspace'
 metas:
   name: indexer
   py_modules:
     - workspace/__init__.py
-  workspace: '/workspace/workspace'
+  workspace: '/docker-workspace'
 requests:
   on:
     SearchRequest:

--- a/advanced-vector-search/yaml/faiss-indexer.yml
+++ b/advanced-vector-search/yaml/faiss-indexer.yml
@@ -2,30 +2,31 @@
 components:
   - !FaissIndexer
     with:
-      index_key: 'IVF10,PQ4'
-      train_filepath: '/workspace/workspace/train.tgz'
+      index_key: $JINA_FAISS_INDEX_KEY
+      distance: $JINA_FAISS_DISTANCE
+      normalize: $JINA_FAISS_NORMALIZE
+      nprobe: $JINA_FAISS_NPROBE
+      train_filepath: '/docker-workspace/train.tgz'
       index_filename: 'index.gz'
       ref_indexer:
         !NumpyIndexer
         metas:
-          workspace: '/workspace/workspace'
+          workspace: '/docker-workspace'
           name: wrapidx
         with:
           index_filename: 'index.gz'
     metas:
-      workspace: '/workspace/workspace'
       name: faissidx
   - !BinaryPbIndexer
     with:
       index_filename: doc.gz
     metas:
       name: docidx
-      workspace: '/workspace/workspace'
 metas:
   name: indexer
   py_modules:
     - workspace/__init__.py
-  workspace: '/workspace/workspace'
+  workspace: '/docker-workspace'
 requests:
   on:
     SearchRequest:

--- a/advanced-vector-search/yaml/hub-annoy-indexer.yml
+++ b/advanced-vector-search/yaml/hub-annoy-indexer.yml
@@ -3,8 +3,9 @@ components:
   - !AnnoyIndexer
     with:
       index_filename: 'index.gz'
-      n_trees: 10
-      search_k: -1
+      metric: $JINA_ANNOY_METRIC
+      n_trees: $JINA_ANNOY_NTREES
+      search_k: $JINA_ANNOY_SEARCH_K
       ref_indexer:
         !NumpyIndexer
         metas:
@@ -13,14 +14,12 @@ components:
         with:
           index_filename: 'index.gz'
     metas:
-      workspace: './workspace'
       name: annoyidx
   - !BinaryPbIndexer
     with:
       index_filename: doc.gz
     metas:
       name: docidx
-      workspace: './workspace'
 metas:
   name: indexer
   workspace: './workspace'

--- a/advanced-vector-search/yaml/hub-faiss-indexer.yml
+++ b/advanced-vector-search/yaml/hub-faiss-indexer.yml
@@ -2,7 +2,10 @@
 components:
   - !FaissIndexer
     with:
-      index_key: 'IVF10,PQ4'
+      index_key: $JINA_FAISS_INDEX_KEY
+      distance: $JINA_FAISS_DISTANCE
+      normalize: $JINA_FAISS_NORMALIZE
+      nprobe: $JINA_FAISS_NPROBE
       train_filepath: './workspace/train.tgz'
       index_filename: 'index.gz'
       ref_indexer:
@@ -13,14 +16,12 @@ components:
         with:
           index_filename: 'index.gz'
     metas:
-      workspace: './workspace'
       name: faissidx
   - !BinaryPbIndexer
     with:
       index_filename: doc.gz
     metas:
       name: docidx
-      workspace: './workspace'
 metas:
   name: indexer
   workspace: './workspace'

--- a/advanced-vector-search/yaml/indexer.yml
+++ b/advanced-vector-search/yaml/indexer.yml
@@ -4,14 +4,12 @@ components:
     with:
       index_filename: 'index.gz'
     metas:
-      workspace: './workspace'
       name: wrapidx
   - !BinaryPbIndexer
     with:
       index_filename: doc.gz
     metas:
       name: docidx
-      workspace: './workspace'
 metas:
   name: indexer
   workspace: './workspace'

--- a/advanced-vector-search/yaml/merge-matches-sort.yml
+++ b/advanced-vector-search/yaml/merge-matches-sort.yml
@@ -1,0 +1,17 @@
+!BaseExecutor
+with: {}
+metas:
+  name: merge_matches_topk
+requests:
+  on:
+    [SearchRequest, TrainRequest, IndexRequest, DeleteRequest, UpdateRequest]:
+      - !ReduceAllDriver
+        with:
+          traversal_paths: ['m']
+      - !SortQL
+        with:
+          reverse: $JINA_DISTANCE_REVERSE
+          traversal_paths: ['m']
+          field: 'score__value'
+    ControlRequest:
+      - !ControlReqDriver {}


### PR DESCRIPTION
**Changes introduced**
- Adapt to latest changes in `workspace` configurations
- Adapt scripts to use `sift` and `siftsmall`
- Prepare dockerfile for `sift`
- Parametrize the `Faiss` and `Annoy` Indexers parameters so that the user can tweak them when using the docker image

**TODO**
- [x] Test after next release
- [x] Update README
- [x] Publish new docker image with 1M documents and parametrizable