### PR TITLE
feat: bumped audio version

### DIFF
--- a/audio-search/requirements.txt
+++ b/audio-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]==0.9.23
+jina[hub,http]==1.0.0
 resampy==0.2.2
 tensorflow_cpu==2.1.0
 tf_slim==1.1.0


### PR DESCRIPTION
Worked locally, even thought audio files in jinabox are .ogg which does not work with the audio example. (but that might also be true for 0.9.23)