### PR TITLE
[BUG][FIX] Add dependency check and warning messages

### DIFF
--- a/audio-search/README.md
+++ b/audio-search/README.md
@@ -41,6 +41,15 @@ A demo of neural search for audio data based Vggish model.
 
 ## Install Prerequisites
 
+- In order to run this example, you should have [youtube-dl](https://ytdl-org.github.io/youtube-dl/index.html),
+[ffmpeg](https://ffmpeg.org/download.html) available in your system. Please refer to the specific installation instructions.
+- For MacOS users, a [libmagic](https://filemagic.readthedocs.io/en/latest/guide.html)
+installation will furtherly be needed and can be obtained by running
+```bash
+brew install libmagic
+```
+
+- You can add to your system the python libraries required for this example by running the following:
 ```bash
 pip install -r requirements.txt
 ```
@@ -63,22 +72,27 @@ After preparing the data, here is how the folder looks like,
 ├── README.md
 ├── app.py
 ├── data
+├── ├── metadata
+│   │   └── eval_segments.csv
 │   ├── YjmN-c5mDxfw.wav
 │   ├── Yjo9lFbGXf_0.wav
 │   └── Yjzij1UX73kU.wav
-├── download.sh
+├── download_data.sh
+├── download_model.sh
 ├── flows
 │   ├── index.yml
 │   └── query.yml
+├── get_data.sh
 ├── models
 │   ├── vggish_model.ckpt
 │   └── vggish_pca_params.npz
 ├── pods
-│   ├── craft.yml
+│   ├── chunk_merger.yml
 │   ├── customized_executors.py
 │   ├── doc.yml
 │   ├── encode.yml
 │   ├── rank.yml
+│   ├── segment.yml
 │   ├── vec.yml
 │   └── vggish
 │       ├── mel_features.py
@@ -86,7 +100,13 @@ After preparing the data, here is how the folder looks like,
 │       ├── vggish_params.py
 │       ├── vggish_postprocess.py
 │       └── vggish_slim.py
-└── requirements.txt
+├── requirements.txt
+└── tests
+    ├── data
+    │   ├── YjmN-c5mDxfw.wav
+    │   ├── Yjo9lFbGXf_0.wav
+    │   └── Yjzij1UX73kU.wav
+    └── test_audio_search.py
 ```
 
 

--- a/audio-search/download_data.sh
+++ b/audio-search/download_data.sh
@@ -24,6 +24,23 @@ wget -O $DATA_DIR"/metadata/eval_segments.csv" \
 mkdir metadata
 wget -O "metadata/class_labels_indices.csv" \
   http://storage.googleapis.com/asia_audioset/youtube_corpus/v1/csv/class_labels_indices.csv
+
+if ! [ -x "$(command -v youtube-dl)" ]; then
+  echo 'Warning: required command youtube-dl is not installed. Please install it, then run the script again.' >&2
+  echo 'Installation instructions can be found @ https://ytdl-org.github.io/youtube-dl/download.html .' >&2
+  rm -rf ${REPO_DIR}
+  rm -rf ${DATA_DIR}
+  exit 1
+fi
+
+if ! [ -x "$(command -v ffmpeg)" ]; then
+  echo 'Warning: required command ffmpeg is not installed. Please install it, then run the script again.' >&2
+  echo 'If homebrew is available in your system, you can install ffmpeg by typing: brew install ffmpeg' >&2
+  rm -rf ${REPO_DIR}
+  rm -rf ${DATA_DIR}
+  exit 1
+fi
+
 echo "Download metadata to $DATA_DIR/metadata"
 echo "------ Download wavs ------"
 # mimi_data is hard coded at audio-search/audioset_tagging_cnn/utils/dataset.py::L204


### PR DESCRIPTION
In the audio-search example, while downloading data, an external git repository is cloned and its code is used.

From this external module [ https://github.com/qiuqiangkong/audioset_tagging_cnn.git ] the python script [./utils/dataset.py] is launched. This script includes an hardcoded os.command to youtube-dl and ffmpeg.

These two dependencies are not part of any default unix distro, but they are not listed in any requirements file as well.

This PR includes:
  - a check for the commands' existence inside the data download script
  - an error message in case the dependencies are not found, with an install suggestion
  - the update of the README file, in order to advice the user of the dependencies