### PR TITLE
ci: set fail-fast false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   examples-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest] 
         python-version: [3.7]


### PR DESCRIPTION
Other test jobs will be canceled once one test fails. So adding fail-fast: false can help us find out other failing tests. 