### PR TITLE
fix: update object-search requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest] 
         python-version: [3.7]
-        path: [multires-lyrics-search, advanced-vector-search, fashion-example-query, tumblr-gif-search, pokedex-with-bit, audio-search]
+        path: [multires-lyrics-search, advanced-vector-search, fashion-example-query, tumblr-gif-search, pokedex-with-bit, audio-search, object-search]
 
     steps:
       - uses: actions/checkout@v2

--- a/object-search/Dockerfile
+++ b/object-search/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:0.6.7
+FROM jinaai/jina
 
 ADD requirements.txt .
 

--- a/object-search/README.md
+++ b/object-search/README.md
@@ -37,6 +37,7 @@ The code can of course run natively on your local machine, please [read the Jina
 **Table of Contents**
 
 - [Download and Extract Data](#download-and-extract-data)
+- [Install](#install)
 - [Index Image Data](#index-image-data)
 - [Start the Server](#start-the-server)
 - [Query via REST API](#query-via-rest-api)
@@ -61,6 +62,12 @@ mv Images data/f8k/images
 ```
 
 Note: Flickr8k is not an ideal dataset but we are using due to its small size.
+
+## Install
+
+```bash
+pip install -r requirements.txt
+```
 
 ## Index Image Data
 <p align="center">

--- a/object-search/flow-index.yml
+++ b/object-search/flow-index.yml
@@ -1,29 +1,28 @@
 !Flow
-with:
-  logserver: false
+version: '1'
 pods:
-  read:
+  - name: read
     uses: pods/craft-reader.yml
     read_only: true
-  object:
+  - name: object
     uses: pods/craft-object.yml
     read_only: true
-  normalize:
+  - name: normalize
     uses: pods/craft-normalize.yml
     read_only: true
-  encode:
+  - name: encode
     uses: pods/encode.yml
     parallel: $PARALLEL
     timeout_ready: 600000
     read_only: true
-  vec_idx:
+  - name: vec_idx
     uses: pods/vec.yml
     shards: $SHARDS
     separated_workspace: true
     polling: all
     uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
-  chunk_idx:
+  - name: chunk_idx
     uses: pods/chunk.yml
     needs: [object]
     shards: $SHARDS
@@ -31,7 +30,7 @@ pods:
     polling: all
     uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
-  doc_idx:
+  - name: doc_idx
     uses: pods/doc.yml
     needs: [gateway]
     shards: $SHARDS
@@ -39,7 +38,7 @@ pods:
     polling: all
     uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
-  join_all:
+  - name: join_all
     uses: _merge
     needs: [doc_idx, vec_idx, chunk_idx]
     read_only: true

--- a/object-search/flow-query-object.yml
+++ b/object-search/flow-query-object.yml
@@ -1,25 +1,30 @@
 !Flow
+version: '1'
 with:
   read_only: true  # better add this in the query time
-  rest_api: true
   port_expose: $JINA_PORT
+  timeout_ready: 600000
 pods:
-  normalizer:
+  - name: normalizer
+    method: add
     uses: pods/craft-reader.yml
     read_only: true
     parallel: $PARALLEL
-  tf_encode:
+  - name: tf_encode
+    method: add
     uses: pods/encode.yml
     parallel: $PARALLEL
     timeout_ready: 600000
-  vec_idx:
+  - name: vec_idx
+    method: add
     uses: pods/vec.yml
     shards: $SHARDS
     separated_workspace: true
     polling: all
     uses_reducing: _merge_all
     timeout_ready: 100000 # larger timeout as in query time will read all the data
-  chunk_idx:
+  - name: chunk_idx
+    method: add
     uses: pods/chunk.yml
     shards: $SHARDS
     separated_workspace: true

--- a/object-search/pods/rank.yml
+++ b/object-search/pods/rank.yml
@@ -1,8 +1,11 @@
-!MinRanker
+!SimpleAggregateRanker
+with:
+  aggregate_function: 'min'
+  inverse_score: true
 requests:
   on:
     SearchRequest:
-      - !CollectMatches2DocRankDriver
+      - !AggregateMatches2DocRankDriver
         with:
           traversal_paths: ['m']
     ControlRequest:

--- a/object-search/requirements.txt
+++ b/object-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[http]
-torch
-torchvision
-Pillow
+jina[http]==0.9.1
+torch==1.6.0
+torchvision==0.7.0
+Pillow==8.1.0

--- a/object-search/requirements.txt
+++ b/object-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[http]==0.9.1
+jina[http]==1.0.5
 torch==1.6.0
 torchvision==0.7.0
 Pillow==8.1.0


### PR DESCRIPTION
Since Minranker is removed, 'search original' cannot work.
And in Jina==1.0.4 when do indexing, `AttributeError: meta_info is not recognized` occurs.

- [x] Specify the working environments for object-search.
- [x] fix ranker
- [x] fix segmenter in hub -> https://github.com/jina-ai/jina-hub/pull/4688
- [x] add into ci

