### PR TITLE
fix[tumblr]: change ranker

### DIFF
--- a/tumblr-gif-search/index/rank.yml
+++ b/tumblr-gif-search/index/rank.yml
@@ -1,4 +1,7 @@
-!BiMatchRanker
+!SimpleAggregateRanker
+with:
+  aggregate_function: 'min'
+  inverse_score: true
 requests:
   on:
     [SearchRequest, IndexRequest]:


### PR DESCRIPTION
tumblr is failing because we need to adapt bimatch ranker to change 'length' to 'weight' or use other ways of implementation.
This is a PR to demo a workaround for this example.(replace the ranker).
But I prefer to use different rankers in our examples.