### PR TITLE
refactor: wiki ex uses REST for CRUD

### DIFF
--- a/wikipedia-sentences/README.md
+++ b/wikipedia-sentences/README.md
@@ -57,10 +57,10 @@ python app.py -t query_restful
 Then:
 
 ```sh
-curl --request POST -d '{"top_k": 10, "mode": "search",  "data": ["hello world"]}' -H 'Content-Type: application/json' 'http://0.0.0.0:45678/api/search'
+curl --request POST -d '{"top_k": 10, "mode": "search",  "data": ["hello world"]}' -H 'Content-Type: application/json' 'http://0.0.0.0:45678/search'
 ````
 
-Or use [Jinabox](https://jina.ai/jinabox.js/) with endpoint `http://127.0.0.1:45678/api/search`
+Or use [Jinabox](https://jina.ai/jinabox.js/) with endpoint `http://127.0.0.1:45678/search`
 
 ### From the Terminal
 

--- a/wikipedia-sentences/flows/index.yml
+++ b/wikipedia-sentences/flows/index.yml
@@ -1,5 +1,7 @@
 !Flow
 version: '1'
+with:
+  restful: True
 pods:
   - name: encoder
     uses: pods/encode.yml

--- a/wikipedia-sentences/flows/query.yml
+++ b/wikipedia-sentences/flows/query.yml
@@ -1,6 +1,7 @@
 !Flow
 version: '1'
 with:
+  restful: True
   read_only: true
   port_expose: $JINA_PORT
 pods:

--- a/wikipedia-sentences/requirements.txt
+++ b/wikipedia-sentences/requirements.txt
@@ -1,4 +1,4 @@
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1
-jina[scipy, http]==1.0.0
+jina[scipy, http]==1.1.0


### PR DESCRIPTION
- update Jina to `1.1.0`
- modify flow yamls to enable REST API
- add index_rest that indexes docs using the `/index` REST API
- add index_rest to click options
- change README to point towards `/search` (NOT `/api/search`)