### PR TITLE
fix: adv vector search eg using CRUD REST

### DIFF
--- a/advanced-vector-search/app.py
+++ b/advanced-vector-search/app.py
@@ -9,6 +9,7 @@ import os
 
 from collections import defaultdict
 from functools import partial
+import requests
 
 from jina.flow import Flow
 from jina import Document
@@ -66,7 +67,7 @@ def index_generator(db_file_path: str):
 
 
 def index_restful(num_docs):
-    f = Flow().load_config('flows/index.yml')
+    f = Flow().load_config('flow-index.yml')
 
     with f:
         data_path = os.path.join(os.path.dirname(__file__), os.environ.get('JINA_DATA_FILE', None))

--- a/advanced-vector-search/flow-index.yml
+++ b/advanced-vector-search/flow-index.yml
@@ -1,5 +1,7 @@
 !Flow
 version: '1'
+with:
+  restful: True
 pods:
   - name: encoder
     uses: yaml/encode.yml

--- a/advanced-vector-search/flow-query.yml
+++ b/advanced-vector-search/flow-query.yml
@@ -4,6 +4,7 @@ env:
   OMP_NUM_THREADS: ${{OMP_NUM_THREADS}}
 with:
   read_only: true
+  restful: True
 pods:
   - name: encoder
     show_exc_info: true

--- a/advanced-vector-search/requirements.txt
+++ b/advanced-vector-search/requirements.txt
@@ -1,4 +1,4 @@
 docker==4.0.1
 click==7.1.2
-jina[hub]==1.0.6
+jina[hub]==1.1.0
 

--- a/advanced-vector-search/tests/test_advanced_vectors_search.py
+++ b/advanced-vector-search/tests/test_advanced_vectors_search.py
@@ -17,11 +17,11 @@ def sift_data():
 
 @pytest.fixture(scope='session')
 def index():
-    run(task='index', top_k=100, indexer_query_type='numpy')
+    run(task='index', top_k=100, num_docs=500, indexer_query_type='numpy')
     yield
 
 
 @pytest.mark.parametrize('index_type, expected', [('numpy', 90), ('annoy', 43), ('faiss', 30)])
 def test_advanced_search_example(sift_data, index, index_type, expected):
-    evaluation = run(task='query', top_k=100, indexer_query_type=index_type)
+    evaluation = run(task='query', top_k=100, num_docs=500, indexer_query_type=index_type)
     assert int(evaluation) >= expected

--- a/advanced-vector-search/yaml/custom_executors.py
+++ b/advanced-vector-search/yaml/custom_executors.py
@@ -9,4 +9,4 @@ class MyEncoder(BaseNumericEncoder):
         super().__init__(*args, **kwargs)
 
     def encode(self, content: 'np.ndarray', *args, **kwargs):
-        return data
+        return content

--- a/advanced-vector-search/yaml/custom_executors.py
+++ b/advanced-vector-search/yaml/custom_executors.py
@@ -1,4 +1,4 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from jina.executors.encoders import BaseNumericEncoder
@@ -8,5 +8,5 @@ class MyEncoder(BaseNumericEncoder):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def encode(self, data: 'np.ndarray', *args, **kwargs):
+    def encode(self, content: 'np.ndarray', *args, **kwargs):
         return data


### PR DESCRIPTION
update Jina to 1.1.0 (if not already at that version or higher)

modify flow yamls to enable REST API

add index_rest method that indexes docs using the /index REST API

add index_rest as CLI option to -t (via click options)

change README to point towards /search (NOT /api/search)