### PR TITLE
fix: object search using CRUD REST

### DIFF
--- a/object-search/README.md
+++ b/object-search/README.md
@@ -126,6 +126,21 @@ curl --verbose --request POST -d '{"top_k": 10, "mode": "search",  "data": ["dat
 This example shows you how to feed data into Jina via REST gateway. By default, Jina uses a gRPC gateway, which has much higher performance and rich features. If you are interested in that, go ahead and check out our [other examples](https://learn.jina.ai) and [read our documentation on Jina IO](https://docs.jina.ai/chapters/io/#).
 
 
+### With REST API
+
+```sh
+python app.py -t query_restful
+```
+
+Then:
+
+```sh
+curl --request POST -d '{"top_k": 10, "mode": "search",  "data": ["hello world"]}' -H 'Content-Type: application/json' 'http://0.0.0.0:45678/search'
+````
+
+Or use [Jinabox](https://jina.ai/jinabox.js/) with endpoint `http://127.0.0.1:45678/search`
+
+
 ## Troubleshooting
 
 ### Memory Issues

--- a/object-search/app.py
+++ b/object-search/app.py
@@ -1,12 +1,17 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import os
 import shutil
 import sys
+import requests
+import matplotlib.pyplot as plt
 
 import click
 from jina.flow import Flow
+from jina import Document
+from jina.clients.sugary_io import _input_files
+from jina.clients.sugary_io import _input_lines
 from jina.logging import default_logger as logger
 
 
@@ -31,8 +36,41 @@ def config():
     os.environ['JINA_PORT'] = os.environ.get('JINA_PORT', str(45678))
 
 
+def index_restful(num_docs):
+    f = Flow().load_config('flow-index.yml')
+
+    with f:
+        data_path = os.path.join(os.path.dirname(__file__), os.environ.get('JINA_DATA_FILE', None))
+        print(f'Indexing {data_path}')
+        url = f'http://0.0.0.0:{f.port_expose}/index'
+
+        input_docs = _input_lines(
+            filepath=data_path,
+            size=num_docs,
+            read_mode='r',
+        )
+        data_json = {'data': [Document(text=text).dict() for text in input_docs]}
+        print(f'#### {len(data_json["data"])}')
+        r = requests.post(url, json=data_json)
+        if r.status_code != 200:
+            raise Exception(f'api request failed, url: {url}, status: {r.status_code}, content: {r.content}')
+
+
+def query_restful(return_image):
+    f = Flow().load_config(f'flow-query-{return_image}.yml')
+    f.use_rest_gateway()
+    with f:
+        f.block()
+
+
+def dryrun():
+    f = Flow().load_config("flow-index.yml")
+    with f:
+        pass
+
+
 @click.command()
-@click.option('--task', '-task', '-t', type=click.Choice(['index', 'query'], case_sensitive=False))
+@click.option('--task', '-task', '-t', type=click.Choice(['index', 'query', 'index_restful', 'query_restful', 'dryrun'], case_sensitive=False))
 @click.option('--return_image', '-r', default='original', type=click.Choice(['original', 'object'], case_sensitive=False))
 @click.option('--data_path', '-p', default=data_path)
 @click.option('--num_docs', '-n', default=num_docs)
@@ -40,6 +78,19 @@ def config():
 @click.option('--overwrite_workspace', '-overwrite', default=True)
 def main(task, return_image, data_path, num_docs, batch_size, overwrite_workspace):
     config()
+    workspace = os.environ['WORKDIR']
+    if 'index' in task:
+        if os.path.exists(workspace):
+            print(
+                f'\n +------------------------------------------------------------------------------------+ \
+                    \n |                                   🤖🤖🤖                                           | \
+                    \n | The directory {workspace} already exists. Please remove it before indexing again.  | \
+                    \n |                                   🤖🤖🤖                                           | \
+                    \n +------------------------------------------------------------------------------------+'
+            )
+            sys.exit(1)
+
+    print(f'### task = {task}')
     if task == 'index':
         workspace = os.environ['WORKDIR']
         if os.path.exists(workspace):
@@ -52,11 +103,19 @@ def main(task, return_image, data_path, num_docs, batch_size, overwrite_workspac
             clean_workdir()
         f = Flow.load_config('flow-index.yml')
         with f:
-            f.index_files(data_path, batch_size=batch_size, read_mode='rb', size=num_docs)        
+            f.index_files(data_path, batch_size=batch_size, read_mode='rb', size=num_docs)
+    elif task == 'index_restful':
+        index_restful(num_docs)
     elif task == 'query':
         f = Flow.load_config(f'flow-query-{return_image}.yml')
         with f:
             f.block()
+    elif task == 'query_restful':
+        if not os.path.exists(workspace):
+            print(f"The directory {workspace} does not exist. Please index first via `python app.py -t index`")
+        query_restful(return_image)
+    elif task == 'dryrun':
+        dryrun()
 
 
 if __name__ == '__main__':

--- a/object-search/app.py
+++ b/object-search/app.py
@@ -5,12 +5,10 @@ import os
 import shutil
 import sys
 import requests
-import matplotlib.pyplot as plt
 
 import click
 from jina.flow import Flow
 from jina import Document
-from jina.clients.sugary_io import _input_files
 from jina.clients.sugary_io import _input_lines
 from jina.logging import default_logger as logger
 
@@ -33,6 +31,7 @@ def config():
     os.environ['SHARDS'] = str(shards)
     os.environ['WORKDIR'] = './workspace'
     os.makedirs(os.environ['WORKDIR'], exist_ok=True)
+    os.environ['JINA_DATA_FILE'] = os.environ.get('JINA_DATA_FILE', 'data/**/*.jpg')
     os.environ['JINA_PORT'] = os.environ.get('JINA_PORT', str(45678))
 
 

--- a/object-search/flow-index.yml
+++ b/object-search/flow-index.yml
@@ -1,5 +1,7 @@
 !Flow
 version: '1'
+with:
+  restful: True
 pods:
   - name: read
     uses: pods/craft-reader.yml

--- a/object-search/flow-query-object.yml
+++ b/object-search/flow-query-object.yml
@@ -5,6 +5,7 @@ with:
   rest_api: true
   port_expose: $JINA_PORT
   timeout_ready: 600000
+  restful: True
 pods:
   - name: normalizer
     method: add

--- a/object-search/flow-query-original.yml
+++ b/object-search/flow-query-original.yml
@@ -4,6 +4,7 @@ with:
   read_only: true  # better add this in the query time
   rest_api: true
   port_expose: $JINA_PORT
+  restful: True
 pods:
   - name: normalizer
     uses: pods/craft-reader.yml

--- a/object-search/requirements.txt
+++ b/object-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[http]==1.0.8
+jina[http]==1.1.0
 torch==1.6.0
 torchvision==0.7.0
 Pillow==8.1.1


### PR DESCRIPTION
update Jina to 1.1.0

modify flow yamls to enable REST API

add index_rest that indexes docs using the /index REST API

add index_rest to click options

change README to point towards /search (NOT /api/search)