### PR TITLE
feat: add aws access in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
         run: ./.github/ci.sh
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all }}
+          AWS_ACCESS_KEY_ID: AKIAWB5UZPEQHHYDKVUC
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEVBOT_AKIAWB5UZPEQHHYDKVUC }}


### PR DESCRIPTION
This closes https://github.com/jina-ai/examples/issues/536

The CI change itself should not be tested as part for this PR, but I've created a dummy PR where one can see that S3 access works with those credentials added here: https://github.com/jina-ai/examples/pull/539/files