### PR TITLE
Added commands to speed up cloning using sparse checkout

### DIFF
--- a/multimodal-search-pdf/README.md
+++ b/multimodal-search-pdf/README.md
@@ -37,6 +37,18 @@ What's included in this example:
   * [Community](#community)
   * [License](#license)
     
+<details>
+ <summary>How to clone this repo❓</summary>
+ 
+ Because this repo contains many [more example projects](https://github.com/jina-ai/examples/), if you want to clone only this example, you can do this as following
+ 
+ ```bash
+ git clone --depth 1 --filter=blob:none --sparse https://github.com/jina-ai/examples
+ git sparse-checkout set multimodal-search-pdf
+ ```
+</details>
+
+----
 
 ## Data preparation
 

--- a/multimodal-search-pdf/README.md
+++ b/multimodal-search-pdf/README.md
@@ -44,6 +44,7 @@ What's included in this example:
  
  ```bash
  git clone --depth 1 --filter=blob:none --sparse https://github.com/jina-ai/examples
+ cd examples
  git sparse-checkout set multimodal-search-pdf
  ```
 </details>


### PR DESCRIPTION
Some people reported that cloning examples take time, so now I have added quick commands to copy only one example instead of all of them