### PR TITLE
chore: update jinacld version

### DIFF
--- a/perf-script.sh
+++ b/perf-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # required for downloading data from S3
-pip install -e git://github.com/jina-ai/cloud-helper.git@v0.0.1#egg=jinacld_tools
+pip install -e git://github.com/jina-ai/cloud-helper.git@v0.0.2#egg=jinacld_tools
 
 reqs=`find . -name "requirements.txt"`
 folders=()

--- a/util/pull_dataset.py
+++ b/util/pull_dataset.py
@@ -40,7 +40,7 @@ def main(data_set: str, pull_to_dir: str):
     _check_credentials_exist()
     assert os.path.isdir(pull_to_dir), "The pull dir parameter must be an existing directory"
     save_path = os.path.join(pull_to_dir, data_set)
-    s3 = S3(BUCKET_NAME)
+    s3 = S3Bucket(BUCKET_NAME)
     try:
         s3.get(data_set, save_path)
     except Exception as e:

--- a/util/pull_dataset.py
+++ b/util/pull_dataset.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 import click
-from jinacld_tools.aws.services.s3 import S3
+from jinacld_tools.aws.services.s3 import S3Bucket
 
 
 BUCKET_NAME = "jina-examples-datasets"


### PR DESCRIPTION
Use the new version of `jinacld_tools` (used for pulling datasets from S3).

