### PR TITLE
fix pip numbers leakage

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -23,12 +23,12 @@ for example_dir in ${changedExamples[@]}; do
   cd $root_dir/$example_dir
   echo running tests in $example_dir
   pwd
-  if test -f "requirements.txt"; then
+  if test -f "tests/requirements.txt"; then
     if [[ -d "tests/" ]]; then
       python -m venv .venv
       source .venv/bin/activate
       pip install pytest pytest-mock
-      pip install -r requirements.txt
+      pip install -r tests/requirements.txt
       pytest -s -v tests/
       local_exit_code=$?
       deactivate

--- a/advanced-vector-search/requirements.txt
+++ b/advanced-vector-search/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
+jina[hub, http]
 docker==4.0.1
 click==7.1.2
 

--- a/advanced-vector-search/requirements.txt
+++ b/advanced-vector-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 docker==4.0.1
 click==7.1.2
 

--- a/advanced-vector-search/tests/requirements.txt
+++ b/advanced-vector-search/tests/requirements.txt
@@ -1,0 +1,4 @@
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
+docker==4.0.1
+click==7.1.2
+

--- a/audio-search/requirements.txt
+++ b/audio-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 resampy==0.2.2
 tensorflow_cpu==2.2.0
 tf_slim==1.1.0

--- a/audio-search/tests/requirements.txt
+++ b/audio-search/tests/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
 resampy==0.2.2
 tensorflow_cpu==2.2.0
 tf_slim==1.1.0

--- a/chinese-text-search/requirements.txt
+++ b/chinese-text-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1

--- a/chinese-text-search/requirements.txt
+++ b/chinese-text-search/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.1.0#egg=jina[hub, http]
+jina[hub, http]
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1

--- a/cross-modal-search/requirements.txt
+++ b/cross-modal-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 nltk==3.5
 pycocotools==2.0.2
 torchvision==0.8.1

--- a/cross-modal-search/requirements.txt
+++ b/cross-modal-search/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
+jina[hub, http]
 nltk==3.5
 pycocotools==2.0.2
 torchvision==0.8.1

--- a/fashion-example-query/requirements.txt
+++ b/fashion-example-query/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[http]
+jina[http]
 click
 torch==1.7.1
 transformers==4.1.1

--- a/fashion-example-query/requirements.txt
+++ b/fashion-example-query/requirements.txt
@@ -1,4 +1,4 @@
-jina[http]
+jina[http]==1.2.0
 click
 torch==1.7.1
 transformers==4.1.1

--- a/fashion-example-query/tests/requirements.txt
+++ b/fashion-example-query/tests/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[http]
+click
+torch==1.7.1
+transformers==4.1.1
+requests~=2.24
+pytest==6.1.2

--- a/multimodal-search-pdf/requirements.txt
+++ b/multimodal-search-pdf/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 click==7.1.2
 transformers==4.1.1
 torch==1.7.0

--- a/multimodal-search-pdf/tests/requirements.txt
+++ b/multimodal-search-pdf/tests/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
 click==7.1.2
 transformers==4.1.1
 torch==1.7.0

--- a/multimodal-search-tirg/requirements.txt
+++ b/multimodal-search-tirg/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]
+jina[hub, http]==1.2.0
 click==7.1.2
 matplotlib==3.3.3
 pillow==8.1.1

--- a/multimodal-search-tirg/requirements.txt
+++ b/multimodal-search-tirg/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub, http]
+jina[hub, http]
 click==7.1.2
 matplotlib==3.3.3
 pillow==8.1.1

--- a/multires-lyrics-search/requirements.txt
+++ b/multires-lyrics-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
+jina[hub,http]==1.2.0
 torch==1.7.1
 transformers==4.1.1
 requests~=2.24

--- a/multires-lyrics-search/tests/requirements.txt
+++ b/multires-lyrics-search/tests/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
 torch==1.7.1
 transformers==4.1.1
 requests~=2.24

--- a/object-search/requirements.txt
+++ b/object-search/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
+jina[hub,http]
 torch==1.7.0
 torchvision==0.8.1
 Pillow==8.1.1

--- a/object-search/requirements.txt
+++ b/object-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
+jina[hub,http]==1.2.0
 torch==1.7.0
 torchvision==0.8.1
 Pillow==8.1.1

--- a/object-search/tests/requirements.txt
+++ b/object-search/tests/requirements.txt
@@ -1,0 +1,5 @@
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
+torch==1.7.0
+torchvision==0.8.1
+Pillow==8.1.1
+kaggle==1.5.12

--- a/pokedex-with-bit/requirements.txt
+++ b/pokedex-with-bit/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/jina-ai/jina.git@v1.0.5#egg=jina[hub,http,cv]
+jina[hub,http,cv]
 click==7.1.2
 tensorflow-cpu==2.1

--- a/pokedex-with-bit/requirements.txt
+++ b/pokedex-with-bit/requirements.txt
@@ -1,3 +1,3 @@
-jina[hub,http,cv]
+jina[hub,http,cv]==1.2.0
 click==7.1.2
 tensorflow-cpu==2.1

--- a/pokedex-with-bit/tests/requirements.txt
+++ b/pokedex-with-bit/tests/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/jina-ai/jina.git@v1.0.5#egg=jina[hub,http,cv]
+click==7.1.2
+tensorflow-cpu==2.1

--- a/templates/nlp-simple/tests/requirements.txt
+++ b/templates/nlp-simple/tests/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1
+jina[scipy, http]==1.0.0

--- a/tumblr-gif-search/requirements.txt
+++ b/tumblr-gif-search/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
+jina[hub,http]
 click==7.1.2
 aiofiles
 aiohttp

--- a/tumblr-gif-search/requirements.txt
+++ b/tumblr-gif-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
+jina[hub,http]==1.2.0
 click==7.1.2
 aiofiles
 aiohttp

--- a/tumblr-gif-search/tests/requirements.txt
+++ b/tumblr-gif-search/tests/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
+click==7.1.2
+aiofiles
+aiohttp
+tensorflow_cpu >= 2.0
+pillow

--- a/wikipedia-sentences-query-while-indexing/requirements.txt
+++ b/wikipedia-sentences-query-while-indexing/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jina-ai/jina.git@v1.2.3#egg=jina[hub,http,daemon]
+jina[hub,http,daemon]
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1

--- a/wikipedia-sentences-query-while-indexing/requirements.txt
+++ b/wikipedia-sentences-query-while-indexing/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http,daemon]
+jina[hub,http,daemon]==1.2.0
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1

--- a/wikipedia-sentences-query-while-indexing/tests/requirements.txt
+++ b/wikipedia-sentences-query-while-indexing/tests/requirements.txt
@@ -1,0 +1,4 @@
+git+https://github.com/jina-ai/jina.git@v1.2.3#egg=jina[hub,http,daemon]
+click==7.1.2
+transformers==4.1.1
+torch==1.7.1

--- a/wikipedia-sentences/requirements.txt
+++ b/wikipedia-sentences/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub,http]
+jina[hub,http]==1.2.0
 click==7.1.2
 transformers==4.1.1
 torch==1.7.1

--- a/wikipedia-sentences/tests/requirements.txt
+++ b/wikipedia-sentences/tests/requirements.txt
@@ -1,0 +1,4 @@
+git+https://github.com/jina-ai/jina.git@v1.2.0#egg=jina[hub,http]
+click==7.1.2
+transformers==4.1.1
+torch==1.7.1


### PR DESCRIPTION
Fixes https://github.com/jina-ai/internal-tasks/issues/86

At present, anything installed from `requirements.txt` in examples repo is not tracked by pypi, so we can't get those metrics. But do we even want those numbers?

- If it's our CI doing that, we DON'T want those numbers. 
- If it's our users, we DO want those numbers. 
 
This PR creates a separate requirements.txt in each example's `test/` directory, and tells our CI to install from that. 

It reverts `./requirements.txt` to installing from pypi, which is what real users would do.

- test: separate reqs for users and ci. users install direct
- test: set ci to install requirements.txt from test dir
