### PR TITLE
fix: bump Jina version and Port ImageNormalizer and CLIPImageEncoder to use jinahub+docker

### DIFF
--- a/cross-modal-search/Dockerfile
+++ b/cross-modal-search/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:1.2.0
+FROM jinaai/jina:2.0.8-perf
 
 RUN apt-get -y update && apt-get install -y git wget gcc unzip libmagic1
 

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -6,15 +6,13 @@ with:
   port_expose: 45678
   workspace: $JINA_WORKSPACE
 pods:
-  - name: loader                                      # load images from the dataset of image-caption pairs
+  - name: image_normalizer                                  # normalize the dimension of the images
+    uses: pods/image-normalize.yml
     uses: 'jinahub+docker://ImageNormalizer'
+    override_with: {'dtype': 'uint8'}
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]
-  - name: image_normalizer                                  # normalize the dimension of the images
-    uses: pods/image-normalize.yml
-    shards: $JINA_PARALLEL
-    read_only: true
   - name: image_encoder                               # encode images into embeddings with CLIP model
     uses: 'jinahub+docker://CLIPImageEncoder'
     volumes: $HOME/.cache/clip:/root/.cache/clip

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -15,7 +15,8 @@ pods:
     shards: $JINA_PARALLEL
     read_only: true
   - name: image_encoder                               # encode images into embeddings with CLIP model
-    uses: pods/clip/image-encoder.yml
+    uses: 'jinahub+docker://CLIPImageEncoder'
+    volumes: $HOME/.cache/clip:/root/.cache/clip
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -11,7 +11,7 @@ pods:
     read_only: true
     needs: [gateway]
   - name: image_encoder                               # encode images into embeddings with CLIP model
-    uses: 'jinahub+docker://CLIPImageEncoder'
+    uses: 'jinahub://CLIPImageEncoder'
     volumes: $HOME/.cache/clip:/root/.cache/clip
     shards: $JINA_PARALLEL
     timeout_ready: 600000

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -5,10 +5,8 @@ with:
   port_expose: 45678
   workspace: $JINA_WORKSPACE
 pods:
-  - name: image_normalizer                                  # normalize the dimension of the images
-    uses: pods/image-normalize.yml
-    uses: 'jinahub+docker://ImageNormalizer'
-    override_with: {'target_dtype': 'numpy.uint8'}
+  - name: loader                                      # load images from the dataset of image-caption pairs
+    uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -1,7 +1,6 @@
 jtype: Flow
 version: '1'
 with:
-  protocol: http
   prefetch: 10
   port_expose: 45678
   workspace: $JINA_WORKSPACE

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -8,7 +8,7 @@ pods:
   - name: image_normalizer                                  # normalize the dimension of the images
     uses: pods/image-normalize.yml
     uses: 'jinahub+docker://ImageNormalizer'
-    override_with: {'dtype': 'uint8'}
+    override_with: {'target_dtype': 'numpy.uint8'}
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -1,12 +1,13 @@
 jtype: Flow
 version: '1'
 with:
+  protocol: http
   prefetch: 10
   port_expose: 45678
   workspace: $JINA_WORKSPACE
 pods:
   - name: loader                                      # load images from the dataset of image-caption pairs
-    uses: pods/image-load.yml
+    uses: 'jinahub+docker://ImageNormalizer'
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -6,16 +6,12 @@ with:
   port_expose: 45678
   workspace: $JINA_WORKSPACE
 pods:
-  - name: loader                          # load query image
-    uses: pods/image-load.yml
+  - name: normalizer                      # normalize query image
+    uses: 'jinahub+docker://ImageNormalizer'
+    override_with: {'dtype': 'uint8'}
     shards: $JINA_PARALLEL
     read_only: true
     needs: gateway
-  - name: normalizer                      # normalize query image
-    uses: pods/image-normalize.yml
-    shards: $JINA_PARALLEL
-    read_only: true
-    needs: loader
   - name: image_encoder                   # encode query image into embeddings with CLIP model
     polling: any
     uses: 'jinahub+docker://CLIPImageEncoder'

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -1,6 +1,7 @@
 jtype: Flow
 version: '1'
 with:
+  protocol: http
   prefetch: 10
   port_expose: 45678
   workspace: $JINA_WORKSPACE

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -17,7 +17,8 @@ pods:
     needs: loader
   - name: image_encoder                   # encode query image into embeddings with CLIP model
     polling: any
-    uses: pods/clip/image-encoder.yml
+    uses: 'jinahub+docker://CLIPImageEncoder'
+    volumes: $HOME/.cache/clip:/root/.cache/clip
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -12,7 +12,7 @@ pods:
     needs: gateway
   - name: image_encoder                   # encode query image into embeddings with CLIP model
     polling: any
-    uses: 'jinahub+docker://CLIPImageEncoder'
+    uses: 'jinahub://CLIPImageEncoder'
     volumes: $HOME/.cache/clip:/root/.cache/clip
     shards: $JINA_PARALLEL
     timeout_ready: 600000

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -1,7 +1,6 @@
 jtype: Flow
 version: '1'
 with:
-  protocol: http
   prefetch: 10
   port_expose: 45678
   workspace: $JINA_WORKSPACE

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -7,7 +7,7 @@ with:
 pods:
   - name: normalizer                      # normalize query image
     uses: 'jinahub+docker://ImageNormalizer'
-    override_with: {'dtype': 'uint8'}
+    override_with: {'target_dtype': 'numpy.uint8'}
     shards: $JINA_PARALLEL
     read_only: true
     needs: gateway

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -5,9 +5,8 @@ with:
   port_expose: 45678
   workspace: $JINA_WORKSPACE
 pods:
-  - name: normalizer                      # normalize query image
-    uses: 'jinahub+docker://ImageNormalizer'
-    override_with: {'target_dtype': 'numpy.uint8'}
+  - name: loader                          # load query image
+    uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
     needs: gateway
@@ -18,7 +17,7 @@ pods:
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true
-    needs: normalizer
+    needs: loader
   - name: text_indexer                    # index query text
     polling: all
     uses: pods/index-text.yml

--- a/cross-modal-search/pods/executors.py
+++ b/cross-modal-search/pods/executors.py
@@ -45,7 +45,11 @@ class ReciprocalRankEvaluator(Executor):
 class ImageReader(Executor):
     @requests(on='/index')
     def index_read(self, docs: 'DocumentArray', **kwargs):
-        return DocumentArray(list(filter(lambda doc: doc.modality=='image', docs)))
+        array = DocumentArray(list(filter(lambda doc: doc.modality=='image', docs)))
+        for doc in array:
+            doc.convert_image_buffer_to_blob()
+            doc.blob = np.array(doc.blob).astype(np.uint8)
+        return array
 
     @requests(on='/search')
     def search_read(self, docs: 'DocumentArray', **kwargs):
@@ -54,6 +58,8 @@ class ImageReader(Executor):
             return DocumentArray([])
         for doc in image_docs:
             doc.convert_uri_to_buffer()
+            doc.convert_image_buffer_to_blob()
+            doc.blob = doc.blob.astype(np.uint8)
         return image_docs
 
 

--- a/cross-modal-search/requirements.txt
+++ b/cross-modal-search/requirements.txt
@@ -1,7 +1,7 @@
-jina[hub, http]~=2.0.0
+jina[hub, http, chatbot]~=2.0.0
 nltk==3.5
 pycocotools==2.0.2
 python-magic==0.4.20
 click==7.1.2
 kaggle==1.5.12
-git+https://github.com/openai/CLIP.git
+git+git://github.com/jina-ai/jina-commons


### PR DESCRIPTION
This PR bumps the Jina version of cross-modal-search to 2.0.4 and port ImageNormalizer and CLIPImageEncoder to use jinahub+docker