### PR TITLE
fix: temporary fix for cross-modal-search index flow to work on Jina 2.0

### DIFF
--- a/cross-modal-search/app.py
+++ b/cross-modal-search/app.py
@@ -23,8 +23,7 @@ def config():
 
 
 def index_restful():
-    flow = Flow().load_config('flows/flow-index.yml')
-    flow.use_rest_gateway()
+    flow = Flow(protocol='http').load_config('flows/flow-index.yml', override_with={'protocol': 'http'})
     with flow:
         flow.block()
 
@@ -45,7 +44,7 @@ def check_query_result(resp):
 
 
 def index(data_set, num_docs, request_size):
-    flow = Flow.load_config('flows/flow-index.yml')
+    flow = Flow().load_config('flows/flow-index.yml')
     with flow:
         with TimeContext(f'QPS: indexing {num_docs}', logger=flow.logger):
             flow.index(
@@ -57,7 +56,6 @@ def index(data_set, num_docs, request_size):
 
 def query():
     flow = Flow().load_config('flows/flow-query.yml')
-    flow.use_rest_gateway()
     with flow:
         flow.search(inputs=[
             Document(text='a black dog and a spotted dog are fighting', modality='text'),
@@ -67,8 +65,7 @@ def query():
 
 
 def query_restful():
-    flow = Flow().load_config('flows/flow-query.yml')
-    flow.use_rest_gateway()
+    flow = Flow(protocol='http').load_config('flows/flow-query.yml', override_with={'protocol': 'http'})
     with flow:
         flow.block()
 

--- a/cross-modal-search/app.py
+++ b/cross-modal-search/app.py
@@ -23,7 +23,7 @@ def config():
 
 
 def index_restful():
-    flow = Flow(protocol='http').load_config('flows/flow-index.yml', override_with={'protocol': 'http'})
+    flow = Flow().load_config('flows/flow-index.yml', override_with={'protocol': 'http'})
     with flow:
         flow.block()
 
@@ -65,7 +65,7 @@ def query():
 
 
 def query_restful():
-    flow = Flow(protocol='http').load_config('flows/flow-query.yml', override_with={'protocol': 'http'})
+    flow = Flow().load_config('flows/flow-query.yml', override_with={'protocol': 'http'})
     with flow:
         flow.block()
 

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -6,13 +6,15 @@ with:
   workspace: $JINA_WORKSPACE
 pods:
   - name: loader                                      # load images from the dataset of image-caption pairs
+    # uses: 'jinahub+docker://ImageNormalizer'
     uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]
   - name: image_encoder                               # encode images into embeddings with CLIP model
-    uses: 'jinahub+docker://ClipImageEncoder'
-    volumes: $HOME/.cache/clip:/root/.cache/clip
+    # uses: 'jinahub+docker://CLIPImageEncoder'
+    # volumes: $HOME/.cache/clip:/root/.cache/clip
+    uses: pods/clip/image-encoder.yml
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true

--- a/cross-modal-search/flows/flow-index.yml
+++ b/cross-modal-search/flows/flow-index.yml
@@ -6,14 +6,15 @@ with:
   workspace: $JINA_WORKSPACE
 pods:
   - name: loader                                      # load images from the dataset of image-caption pairs
-    # uses: 'jinahub+docker://ImageNormalizer'
     uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
     needs: [gateway]
+  - name: image_normalizer                                  # normalize the dimension of the images
+    uses: pods/image-normalize.yml
+    shards: $JINA_PARALLEL
+    read_only: true
   - name: image_encoder                               # encode images into embeddings with CLIP model
-    # uses: 'jinahub+docker://CLIPImageEncoder'
-    # volumes: $HOME/.cache/clip:/root/.cache/clip
     uses: pods/clip/image-encoder.yml
     shards: $JINA_PARALLEL
     timeout_ready: 600000

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -6,25 +6,22 @@ with:
   workspace: $JINA_WORKSPACE
 pods:
   - name: loader                          # load query image
-    # uses: 'jinahub+docker://ImageNormalizer'
     uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
     needs: gateway
-#  - name: normalizer                      # normalize query image
-#    uses: pods/image-normalize.yml
-#    shards: $JINA_PARALLEL
-#    read_only: true
-#    needs: loader
+  - name: normalizer                      # normalize query image
+    uses: pods/image-normalize.yml
+    shards: $JINA_PARALLEL
+    read_only: true
+    needs: loader
   - name: image_encoder                   # encode query image into embeddings with CLIP model
     polling: any
-     # uses: 'jinahub+docker://ClIPImageEncoder'
-     # volumes: $HOME/.cache/clip:/root/.cache/clip
     uses: pods/clip/image-encoder.yml
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true
-    needs: loader
+    needs: normalizer
   - name: text_indexer                    # index query text
     polling: all
     uses: pods/index-text.yml

--- a/cross-modal-search/flows/flow-query.yml
+++ b/cross-modal-search/flows/flow-query.yml
@@ -6,6 +6,7 @@ with:
   workspace: $JINA_WORKSPACE
 pods:
   - name: loader                          # load query image
+    # uses: 'jinahub+docker://ImageNormalizer'
     uses: pods/image-load.yml
     shards: $JINA_PARALLEL
     read_only: true
@@ -17,8 +18,9 @@ pods:
 #    needs: loader
   - name: image_encoder                   # encode query image into embeddings with CLIP model
     polling: any
-    uses: 'jinahub+docker://ClipImageEncoder'
-    volumes: $HOME/.cache/clip:/root/.cache/clip
+     # uses: 'jinahub+docker://ClIPImageEncoder'
+     # volumes: $HOME/.cache/clip:/root/.cache/clip
+    uses: pods/clip/image-encoder.yml
     shards: $JINA_PARALLEL
     timeout_ready: 600000
     read_only: true

--- a/cross-modal-search/pods/clip/image-encoder.yml
+++ b/cross-modal-search/pods/clip/image-encoder.yml
@@ -1,0 +1,5 @@
+# encodes text into embeddings with CLIP model
+jtype: CLIPImageEncoder
+metas:
+  py_modules:
+    - '../executors.py'

--- a/cross-modal-search/pods/executors.py
+++ b/cross-modal-search/pods/executors.py
@@ -45,12 +45,7 @@ class ReciprocalRankEvaluator(Executor):
 class ImageReader(Executor):
     @requests(on='/index')
     def index_read(self, docs: 'DocumentArray', **kwargs):
-
-        image_docs = DocumentArray(list(filter(lambda doc: doc.modality=='image', docs)))
-        for doc in image_docs:
-            img = Image.open(io.BytesIO(doc.buffer))
-            doc.content = np.array(img).astype('uint8')
-        return image_docs
+        return DocumentArray(list(filter(lambda doc: doc.modality=='image', docs)))
 
     @requests(on='/search')
     def search_read(self, docs: 'DocumentArray', **kwargs):
@@ -59,9 +54,6 @@ class ImageReader(Executor):
             return DocumentArray([])
         for doc in image_docs:
             doc.convert_uri_to_buffer()
-            doc.convert_image_buffer_to_blob()
-            doc.blob = np.array(doc.blob).astype('uint8')
-            # doc.pop('chunks', 'uri')
         return image_docs
 
 
@@ -98,6 +90,7 @@ class ImageNormalizer(Executor):
             img = Image.open(io.BytesIO(doc.buffer))
             img = self._normalize(img)
             doc.content = np.array(img).astype('float32')
+            doc.blob = np.moveaxis(doc.blob, -1, 0)
             # doc.content = img
 
     def _normalize(self, img):

--- a/cross-modal-search/requirements.txt
+++ b/cross-modal-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]==2.0.5
+jina[hub, http]~=2.0.0
 nltk==3.5
 pycocotools==2.0.2
 python-magic==0.4.20

--- a/cross-modal-search/requirements.txt
+++ b/cross-modal-search/requirements.txt
@@ -1,4 +1,4 @@
-jina[hub, http]==2.0.0rc5
+jina[hub, http]==2.0.5
 nltk==3.5
 pycocotools==2.0.2
 python-magic==0.4.20


### PR DESCRIPTION
The fix temporarily reverts previous change that ports CLIPEncoder to Jinahub because a hang occurs. Also remove the lines `f.use_rest_gatway()` as the function is now removed. 