### PR TITLE
chore(qwi): update to 2.1.0

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -36,7 +36,8 @@ for example_dir in ${changedExamples[@]}; do
                   -v /tmp/jinad:/tmp/jinad \
                   -p 8000:8000 \
                   --name jinad \
-                  -d jinaai/jina:master-daemon
+                  -d jinaai/jina:2.1.0-daemon
+        sleep 5
       fi
       pytest -s -v tests/
       local_exit_code=$?

--- a/wikipedia-sentences-query-while-indexing/README.md
+++ b/wikipedia-sentences-query-while-indexing/README.md
@@ -94,7 +94,7 @@ In this example, we use [JinaD]((https://docs.jina.ai/advanced/daemon/#remote-ma
            -v /tmp/jinad:/tmp/jinad \
            -p 8000:8000 \
            --name jinad \
-           -d jinaai/jina:master-daemon
+           -d jinaai/jina:2.1.0-daemon
    ```
 
 2. Run `python app.py -t flows`

--- a/wikipedia-sentences-query-while-indexing/requirements.txt
+++ b/wikipedia-sentences-query-while-indexing/requirements.txt
@@ -1,3 +1,3 @@
-jina[daemon]==2.0.23
+jina[daemon]==2.1.0
 kaggle==1.5.12
 click==7.1.2

--- a/wikipedia-sentences-query-while-indexing/tests/requirements.txt
+++ b/wikipedia-sentences-query-while-indexing/tests/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/jina-ai/jina.git@v2.0.23#egg=jina[daemon]
+git+https://github.com/jina-ai/jina.git@v2.1.0#egg=jina[daemon]
 click==7.1.2


### PR DESCRIPTION
Instead of using `master-daemon` image for JinaD, this PR changes both jina version & jinad docker image version to `2.1.0`. 